### PR TITLE
Fixed windows compatibility - introduced cross-spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,42 +1,43 @@
 {
-    "name": "concurrently",
-    "version": "0.0.5-dev",
-    "description": "Run commands concurrently",
-    "main": "src/main.js",
-    "bin": {
-        "concurrent": "./src/main.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/kimmobrunfeldt/concurrently.git"
-    },
-    "keywords": [
-        "bash",
-        "concurrent",
-        "parallel",
-        "concurrently",
-        "command",
-        "sh"
-    ],
-    "author": "Kimmo Brunfeldt",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/kimmobrunfeldt/concurrently/issues"
-    },
-    "homepage": "https://github.com/kimmobrunfeldt/concurrently",
-    "dependencies": {
-        "bluebird": "2.9.6",
-        "chalk": "0.5.1",
-        "commander": "2.6.0",
-        "lodash": "3.1.0",
-        "rx": "2.3.24"
-    },
-    "devDependencies": {
-        "chai": "^1.10.0",
-        "mocha": "^2.1.0",
-        "mustache": "^1.0.0",
-        "semver": "^4.2.0",
-        "shelljs": "^0.3.0",
-        "string": "^3.0.0"
-    }
+  "name": "concurrently",
+  "version": "0.0.5-dev",
+  "description": "Run commands concurrently",
+  "main": "src/main.js",
+  "bin": {
+    "concurrent": "./src/main.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kimmobrunfeldt/concurrently.git"
+  },
+  "keywords": [
+    "bash",
+    "concurrent",
+    "parallel",
+    "concurrently",
+    "command",
+    "sh"
+  ],
+  "author": "Kimmo Brunfeldt",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kimmobrunfeldt/concurrently/issues"
+  },
+  "homepage": "https://github.com/kimmobrunfeldt/concurrently",
+  "dependencies": {
+    "bluebird": "2.9.6",
+    "chalk": "0.5.1",
+    "commander": "2.6.0",
+    "cross-spawn": "^0.2.9",
+    "lodash": "3.1.0",
+    "rx": "2.3.24"
+  },
+  "devDependencies": {
+    "chai": "^1.10.0",
+    "mocha": "^2.1.0",
+    "mustache": "^1.0.0",
+    "semver": "^4.2.0",
+    "shelljs": "^0.3.0",
+    "string": "^3.0.0"
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ var Promise = require('bluebird');
 var program = require('commander');
 var _ = require('lodash');
 var chalk = require('chalk');
-var childProcess = Promise.promisifyAll(require('child_process'));
+var spawn = Promise.promisifyAll(require('cross-spawn'));
 require('./lodash-mixins');
 
 
@@ -106,7 +106,7 @@ function run(commands) {
         var parts = cmd.split(' ');
         var child;
         try {
-            child = childProcess.spawn(_.head(parts), _.tail(parts));
+            child = spawn(_.head(parts), _.tail(parts));
         } catch (e) {
             logError('', 'Error occured when executing command: ' + cmd);
             logError('', e.stack);


### PR DESCRIPTION
Trying to execute npm (or anything that is not an exe or cmd) on windows in DOS or bash results in an ENOENT error. It can't find the command.
```bash
 $ concurrent "npm -v"
Error occured when executing command: npm -v
Error: spawn npm ENOENT
    at exports._errnoException (util.js:734:11)
    at Process.ChildProcess._handle.onexit (child_process.js:1022:32)
    at child_process.js:1114:20
    at process._tickCallback (node.js:350:11)
    at Function.Module.runMain (module.js:487:11)
    at startup (node.js:112:16)
    at node.js:863:3
[0] npm -v exited with code -4058
```
This is because the spawn command ignores PATHEXT on windows: https://github.com/joyent/node/issues/2318

The workaround is to use the `exec` function or a platform compatible shim like https://github.com/IndigoUnited/node-cross-spawn .

This pull request is the cross-spawn implementation.