### PR TITLE
Add the ability to escape commands (or directory names) with a slash

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -104,6 +104,8 @@ function stripCmdQuotes(cmd) {
     // Removes the quotes surrounding a command.
     if (cmd[0] === '"' || cmd[0] === '\'') {
         return cmd.substr(1, cmd.length - 2);
+    } else {
+        return cmd;
     }
 }
 
@@ -143,7 +145,7 @@ function run(commands) {
         cmd = stripCmdQuotes(cmd);
 
         // Split the command up in the command path and its arguments.
-        parts = separateCmdArgs(cmd);
+        var parts = separateCmdArgs(cmd);
 
         var child;
         try {

--- a/src/main.js
+++ b/src/main.js
@@ -106,16 +106,12 @@ function run(commands) {
         // We're splitting up the command into space-separated parts.
         // To permit commands with spaces in the name (or directory name),
         // double slashes is a usable escape sequence.
-        var parts = cmd.split(/[^\\](\s)/g)
-            .filter(function(part) {
-                // Remove empty strings.
-                return part != ' ';
-            })
-            .map(function(part) {
-                // Remove the escape slashes from the command.
-                return part.trim().replace('\\ ', ' ');
-            });
-
+        var divide = cmd.search(/[^\\]\s/) + 1;
+        var path = cmd.substr(0, divide).replace('\\ ', ' ');
+        var args = cmd.substr(divide).split(' ').filter(function(part) {
+            return part.trim() != '';
+        });
+        var parts = [path].concat(args);
         var child;
         try {
             child = spawn(_.head(parts), _.tail(parts));

--- a/src/main.js
+++ b/src/main.js
@@ -100,31 +100,50 @@ function mergeDefaultsWithArgs(config) {
     return _.merge(config, program);
 }
 
+function stripCmdQuotes(cmd) {
+    // Removes the quotes surrounding a command.
+    if (cmd[0] === '"' || cmd[0] === '\'') {
+        return cmd.substr(1, cmd.length - 2);
+    }
+}
+
+function separateCmdArgs(cmd) {
+    // We're splitting up the command into space-separated parts.
+    // The first item is the command, all remaining items are the
+    // arguments. To permit commands with spaces in the name
+    // (or directory name), double slashes is a usable escape sequence.
+    var escape = cmd.search('\\\s'),
+        divide = cmd.search(/[^\\]\s/),
+        path, args, parts;
+
+    if (escape === -1) {
+        // Not an escaped path. Most common case.
+        parts = cmd.split(' ');
+    } else if (escape > -1 && divide === -1) {
+        // Escaped path without arguments.
+        parts = [cmd.replace('\\ ', ' ')];
+    } else {
+        // Escaped path with arguments.
+        path = cmd.substr(0, divide + 1).replace('\\ ', ' ');
+        args = cmd.substr(divide + 1).split(' ').filter(function(part) {
+            return part.trim() != '';
+        });
+        parts = [path].concat(args);
+    }
+
+    // Parts contains the command as the first item and any arguments
+    // as subsequent items.
+    return parts;
+}
+
 function run(commands) {
     var childrenInfo = {};
     var children = _.map(commands, function(cmd, index) {
-        // We're splitting up the command into space-separated parts.
-        // The first item is the command, all remaining items are the
-        // arguments. To permit commands with spaces in the name
-        // (or directory name), double slashes is a usable escape sequence.
-        var escape = cmd.search('\\\s'),
-            divide = cmd.search(/[^\\]\s/),
-            path, args, parts;
+        // Remove quotes.
+        cmd = stripCmdQuotes(cmd);
 
-        if (escape > -1 && divide === -1) {
-            // Escaped path without arguments.
-            parts = [cmd.replace('\\ ', ' ')];
-        } else if (escape === -1) {
-            // Not an escaped path.
-            parts = cmd.split(' ');
-        } else {
-            // Escaped path with arguments.
-            path = cmd.substr(0, divide + 1).replace('\\ ', ' ');
-            args = cmd.substr(divide + 1).split(' ').filter(function(part) {
-                return part.trim() != '';
-            });
-            parts = [path].concat(args);
-        }
+        // Split the command up in the command path and its arguments.
+        parts = separateCmdArgs(cmd);
 
         var child;
         try {

--- a/src/main.js
+++ b/src/main.js
@@ -103,7 +103,19 @@ function mergeDefaultsWithArgs(config) {
 function run(commands) {
     var childrenInfo = {};
     var children = _.map(commands, function(cmd, index) {
-        var parts = cmd.split(' ');
+        // We're splitting up the command into space-separated parts.
+        // To permit commands with spaces in the name (or directory name),
+        // double slashes is a usable escape sequence.
+        var parts = cmd.split(/[^\\](\s)/g)
+            .filter(function(part) {
+                // Remove empty strings.
+                return part != ' ';
+            })
+            .map(function(part) {
+                // Remove the escape slashes from the command.
+                return part.trim().replace('\\ ', ' ');
+            });
+
         var child;
         try {
             child = spawn(_.head(parts), _.tail(parts));


### PR DESCRIPTION
Currently it's not possible (to my knowledge?) to run a command that contains a space. For example:

    $ concurrent "/Users/msikma/Public projects/react-redux-dada/run.js --argument"

This will fail because everything to the left of the space is considered to be the command's full path, and everything on the right is the arguments. The intent is to call everything inside the quotation marks as a command with no arguments.

Normally, in a terminal, you'd fix this by escaping the space in the path, but Concurrently splits the command by space. This PR replaces that split with one that takes escape slashes into account. Making the following possible: 

    $ concurrent "/Users/msikma/Public\ projects/react-redux-dada/run.js --argument"

This passes all tests and handles cases with and without escaped path, with and without arguments.