### PR TITLE
Add next-signal option to concurrently

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -66,7 +66,7 @@ function parseArgs() {
             ' disables prettifying and colors'
         )
         .option(
-            '-n, --next-signal',
+            '-n, --next-signal [nextSignal]',
             'if string, commands are launched in sequence. Launches the next process\n' +
             'when the current process logs this value. Possible values: string or false'
         )

--- a/src/main.js
+++ b/src/main.js
@@ -28,12 +28,17 @@ var config = {
     color: true,
 
     // If true, the output will only be raw output of processes, nothing more
-    raw: false
+    raw: false,
+
+    // If string, commands are launched in sequence. Launches the next process
+    // when the current process logs this value. Possible values: string or false
+    nextSignal: false
 };
 
 function main() {
     parseArgs();
     config = mergeDefaultsWithArgs(config);
+    config.nextSignal = config.nextSignal ? RegExp(config.nextSignal) : null;
     run(program.args);
 }
 
@@ -59,6 +64,10 @@ function parseArgs() {
             '-r, --raw',
             'output only raw output of processes,' +
             ' disables prettifying and colors'
+        )
+        .option(
+            '-n, --next-signal',
+            'do later'
         )
         .option(
             '-l, --prefix-length <length>',
@@ -100,9 +109,49 @@ function mergeDefaultsWithArgs(config) {
     return _.merge(config, program);
 }
 
+function forEachGenerator(arr, func) {
+    var i = 0;
+
+    function next() {
+        if (++i > arr.length) return;
+        func(arr[i - 1], i - 1, next);
+    }
+    next();
+}
+
 function run(commands) {
     var childrenInfo = {};
-    var children = _.map(commands, function(cmd, index) {
+    var children = [];
+
+    var nextFunc;
+    var subscribers = subscribers = [
+        new StreamSubscriber(function(event) {
+            var prefix = getPrefix(childrenInfo, event.child);
+            var str = event.data.toString();
+            if (nextFunc && config.nextSignal.test(str)) {
+                nextFunc();
+            } else {
+                log(prefix, str);
+            }
+        }),
+        new StreamSubscriber(function(event) {
+            var prefix = getPrefix(childrenInfo, event.child);
+            log(prefix, event.data.toString());
+        }),
+        new StreamSubscriber(function(event) {
+            var command = childrenInfo[event.child.pid].command;
+            logError('', 'Error occured when executing command: ' + command);
+            logError('', event.data.stack);
+        }),
+        new CloseStreamSubscriber(children, childrenInfo)
+    ];
+
+    forEachGenerator(commands, function(cmd, index, next) {
+        nextFunc = config.nextSignal && next;
+        if (!config.nextSignal) {
+            next();
+        }
+
         var parts = cmd.split(' ');
         var child;
         try {
@@ -117,114 +166,90 @@ function run(commands) {
             command: cmd,
             index: index
         };
-        return child;
-    });
+        children.push(child);
 
-    // Transform all process events to rx streams
-    var streams = _.map(children, function(child) {
-        var streamList = [
+        var streamList = _.map([
             Rx.Node.fromReadableStream(child.stdout),
             Rx.Node.fromReadableStream(child.stderr),
             Rx.Node.fromEvent(child, 'error'),
             Rx.Node.fromEvent(child, 'close')
-        ];
-
-        var mappedStreams = _.map(streamList, function(stream) {
+        ], function(stream) {
             return stream.map(function(data) {
                 return {child: child, data: data};
             });
         });
 
-        return {
-            stdout: mappedStreams[0],
-            stderr: mappedStreams[1],
-            error: mappedStreams[2],
-            close: mappedStreams[3]
-        };
-    });
-
-    handleStdout(streams, childrenInfo);
-    handleStderr(streams, childrenInfo);
-    handleClose(streams, children, childrenInfo);
-    handleError(streams, childrenInfo);
-}
-
-function handleStdout(streams, childrenInfo) {
-    var stdoutStreams = _.pluck(streams, 'stdout');
-    var stdoutStream = Rx.Observable.merge.apply(this, stdoutStreams);
-
-    stdoutStream.subscribe(function(event) {
-        var prefix = getPrefix(childrenInfo, event.child);
-        log(prefix, event.data.toString());
+        subscribers.forEach(function(s, i) {
+            s.add(streamList[i]);
+        });
     });
 }
 
-function handleStderr(streams, childrenInfo) {
-    var stderrStreams = _.pluck(streams, 'stderr');
-    var stderrStream = Rx.Observable.merge.apply(this, stderrStreams);
+function StreamSubscriber(subscribe) {
+    var subscription;
+    var streams = [];
 
-    stderrStream.subscribe(function(event) {
-        var prefix = getPrefix(childrenInfo, event.child);
-        log(prefix, event.data.toString());
-    });
+    this.add = function(stream) {
+        if (subscription) {
+            subscription.dispose();
+        }
+        streams.push(stream);
+        var mergedStreams = Rx.Observable.merge.apply(this, streams);
+        subscription = mergedStreams.subscribe(subscribe);
+    };
 }
 
-function handleClose(streams, children, childrenInfo) {
+function CloseStreamSubscriber(children, childrenInfo) {
     var aliveChildren = _.clone(children);
     var exitCodes = [];
 
-    var closeStreams = _.pluck(streams, 'close');
-    var closeStream = Rx.Observable.merge.apply(this, closeStreams);
+    var subscriptions = [];
+    var streams = [];
 
-    // TODO: Is it possible that amount of close events !== count of spawned?
-    closeStream.subscribe(function(event) {
-        var exitCode = event.data;
-        exitCodes.push(exitCode);
-
-        var prefix = getPrefix(childrenInfo, event.child);
-        var command = childrenInfo[event.child.pid].command;
-        logEvent(prefix, command + ' exited with code ' + exitCode);
-
-        aliveChildren = _.filter(aliveChildren, function(child) {
-            return child.pid !== event.child.pid;
+    this.add = function(stream) {
+        subscriptions.forEach(function(s) {
+            s.dispose();
         });
+        streams.push(stream);
+        var mergedStreams = Rx.Observable.merge.apply(this, streams);
 
-        if (aliveChildren.length === 0) {
-            // Final exit code is 0 when all processes ran succesfully,
-            // in other cases exit code 1 is used
-            var someFailed = _.some(exitCodes, function(code) {
-                return code !== 0 || code === null;
+        subscriptions.push(mergedStreams.subscribe(function(event) {
+            var exitCode = event.data;
+            exitCodes.push(exitCode);
+
+            var prefix = getPrefix(childrenInfo, event.child);
+            var command = childrenInfo[event.child.pid].command;
+            logEvent(prefix, command + ' exited with code ' + exitCode);
+
+            aliveChildren = _.filter(aliveChildren, function(child) {
+                return child.pid !== event.child.pid;
             });
-            var finalExitCode = someFailed ? 1 : 0;
-            process.exit(finalExitCode);
+
+            if (aliveChildren.length === 0) {
+                // Final exit code is 0 when all processes ran succesfully,
+                // in other cases exit code 1 is used
+                var someFailed = _.some(exitCodes, function(code) {
+                    return code !== 0 || code === null;
+                });
+                var finalExitCode = someFailed ? 1 : 0;
+                process.exit(finalExitCode);
+            }
+        }));
+
+        if (config.killOthers) {
+            // Give other processes some time to stop cleanly before killing them
+            var delayedExit = mergedStreams.delay(config.killDelay);
+
+            subscriptions.push(delayedExit.subscribe(function() {
+                logEvent('--> ', 'Sending SIGTERM to other processes..');
+
+                // Send SIGTERM to alive children
+                _.each(aliveChildren, function(child) {
+                    child.kill();
+                });
+            }));
         }
-    });
-
-    if (config.killOthers) {
-        // Give other processes some time to stop cleanly before killing them
-        var delayedExit = closeStream.delay(config.killDelay);
-
-        delayedExit.subscribe(function() {
-            logEvent('--> ', 'Sending SIGTERM to other processes..');
-
-            // Send SIGTERM to alive children
-            _.each(aliveChildren, function(child) {
-                child.kill();
-            });
-        });
-    }
-}
-
-function handleError(streams, childrenInfo) {
-    // Output emitted errors from child process
-    var errorStreams = _.pluck(streams, 'error');
-    var processErrorStream = Rx.Observable.merge.apply(this, errorStreams);
-
-    processErrorStream.subscribe(function(event) {
-        var command = childrenInfo[event.child.pid].command;
-        logError('', 'Error occured when executing command: ' + command);
-        logError('', event.data.stack);
-    });
+    };
 }
 
 function colorText(text, color) {

--- a/src/main.js
+++ b/src/main.js
@@ -67,7 +67,8 @@ function parseArgs() {
         )
         .option(
             '-n, --next-signal',
-            'do later'
+            'if string, commands are launched in sequence. Launches the next process\n' +
+            'when the current process logs this value. Possible values: string or false'
         )
         .option(
             '-l, --prefix-length <length>',


### PR DESCRIPTION
The next-signal option allows processes to be booted in serial, allowing us to add processes to Concurrently at runtime in a controlled way. This means we can avoid race conditions and unpredicatable outcomes in our scripts.

I recorded a video of me live-coding this feature in the context of another project:

https://www.youtube.com/watch?v=b10djzVmoaw