### PR TITLE
Add option to return success or failure of the first child to exit

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -200,7 +200,7 @@ function handleClose(streams, children, childrenInfo) {
         });
 
         if (aliveChildren.length === 0) {
-          exit(exitCodes);
+            exit(exitCodes);
         }
     });
 
@@ -222,16 +222,16 @@ function handleClose(streams, children, childrenInfo) {
 function exit(childExitCodes) {
     var success;
     switch (config.success) {
-      case 'first':
-        success = _.first(childExitCodes) === 0;
-        break;
-      case 'last':
-        success = _.last(childExitCodes) === 0;
-        break;
-      default:
-        success = _.every(childExitCodes, function(code) {
-          return code === 0;
-        });
+        case 'first':
+            success = _.first(childExitCodes) === 0;
+            break;
+        case 'last':
+            success = _.last(childExitCodes) === 0;
+            break;
+        default:
+            success = _.every(childExitCodes, function(code) {
+                return code === 0;
+            });
     }
     process.exit(success? 0 : 1);
 }

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -56,8 +56,28 @@ describe('concurrently', function() {
             done();
         });
     });
+
+    it('--success=first should return first exit code', function(done) {
+        run('node ./src/main.js -k --success first "echo" "sleep 1000" ', {pipe: DEBUG_TESTS})
+        // When killed, sleep returns null exit code
+        .then(function(exitCode) {
+            assert.strictEqual(exitCode, 0);
+            done();
+        });
+    });
+
+    it('--success=last should return last exit code', function(done) {
+        // When killed, sleep returns null exit code
+        run('node ./src/main.js -k --success last "echo" "sleep 1000" ', {pipe: DEBUG_TESTS})
+        .then(function(exitCode) {
+            assert.notStrictEqual(exitCode, 0);
+            done();
+        });
+    });
+
 });
 
 function resolve(relativePath) {
     return path.join(testDir, relativePath);
 }
+


### PR DESCRIPTION
### Scenario: Run Automated Tests and Dependencies Concurrently
Given I run a webserver and a test runner with `--kill-others` and `--success first`,
When the test runner completes
Then I expect concurrently to terminate the webserver
And return the exit code of the test runner, regardless of whether the webserver shut down gracefully

----

`first` will stop my test script from returning false positives and make me very happy, but I can't think of a case for `last` that isn't totally contrived... it just seemed like if I add `first`, then I should add `last` too.