### PR TITLE
fix(kill_all_flag): kill main process after killing childs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@
 var Rx = require('rx');
 var Promise = require('bluebird');
 var program = require('commander');
+var child_process = require('child_process');
 var _ = require('lodash');
 var chalk = require('chalk');
 var spawn = Promise.promisifyAll(require('cross-spawn'));
@@ -258,6 +259,8 @@ function handleClose(streams, children, childrenInfo) {
             _.each(aliveChildren, function(child) {
                 child.kill();
             });
+
+            child_process.spawn('kill', [process.pid]);
         });
     }
 }


### PR DESCRIPTION
I really don't sure about PR as I am not profound linux user. But this issue is https://github.com/kimmobrunfeldt/concurrently/issues/4 a real blocker as I believe `concurrently` used most of the time with `npm run`. So with this PR I try to solve this by killing main process after trying to kill childs. At least this kills everything so seems like valid solution.
