### PR TITLE
Fix tests call of sleep, it should take seconds.

### DIFF
--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -41,7 +41,7 @@ describe('concurrently', function() {
     });
 
     it('at least one unsuccessful commands should exit non-zero', function(done) {
-        run('node ./src/main.js "echo" "exit 1" "echo"', {pipe: DEBUG_TESTS})
+        run('node ./src/main.js "echo" "return 1" "echo"', {pipe: DEBUG_TESTS})
         .then(function(exitCode) {
             assert.notStrictEqual(exitCode, 0);
             done();
@@ -50,7 +50,7 @@ describe('concurrently', function() {
 
     it('--kill-others should kill other commands if one dies', function(done) {
         // This test would timeout if kill others option does not work
-        run('node ./src/main.js --kill-others "sleep 1000" "echo" "sleep 1000"', {pipe: DEBUG_TESTS})
+        run('node ./src/main.js --kill-others "sleep 1" "echo" "sleep 1"', {pipe: DEBUG_TESTS})
         .then(function(exitCode) {
             assert.notStrictEqual(exitCode, 0);
             done();
@@ -58,7 +58,7 @@ describe('concurrently', function() {
     });
 
     it('--success=first should return first exit code', function(done) {
-        run('node ./src/main.js -k --success first "echo" "sleep 1000" ', {pipe: DEBUG_TESTS})
+        run('node ./src/main.js -k --success first "echo" "sleep 1" ', {pipe: DEBUG_TESTS})
         // When killed, sleep returns null exit code
         .then(function(exitCode) {
             assert.strictEqual(exitCode, 0);
@@ -68,7 +68,7 @@ describe('concurrently', function() {
 
     it('--success=last should return last exit code', function(done) {
         // When killed, sleep returns null exit code
-        run('node ./src/main.js -k --success last "echo" "sleep 1000" ', {pipe: DEBUG_TESTS})
+        run('node ./src/main.js -k --success last "echo" "sleep 1" ', {pipe: DEBUG_TESTS})
         .then(function(exitCode) {
             assert.notStrictEqual(exitCode, 0);
             done();


### PR DESCRIPTION
The bash sleep command takes second as argument, and don't know why but exit 1, exits with 0 on Windows(didn't test on linux macine).