### PR TITLE
Fix killing of child process on Windows

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ var program = require('commander');
 var _ = require('lodash');
 var chalk = require('chalk');
 var spawn = Promise.promisifyAll(require('cross-spawn'));
+var isWindows = /^win/.test(process.platform);
 
 var config = {
     // Kill other processes if one dies
@@ -264,7 +265,11 @@ function handleClose(streams, children, childrenInfo) {
 
             // Send SIGTERM to alive children
             _.each(aliveChildren, function(child) {
-                child.kill();
+                if(!isWindows) {
+                    child.kill();
+                } else {
+                    spawn('taskkill', ["/pid", child.pid, '/f', '/t']);
+                }
             });
         });
     }

--- a/src/main.js
+++ b/src/main.js
@@ -177,7 +177,7 @@ function run(commands) {
         // Split the command up in the command path and its arguments.
         var parts = separateCmdArgs(cmd);
 
-        var spawnOpts = config.raw ? {stdio: 'inherit'} : {};
+        var spawnOpts = config.raw ? {stdio: 'inherit', 'detached': true} : {'detached': true};
         var child;
         try {
             child = spawn(_.head(parts), _.tail(parts), spawnOpts);
@@ -266,7 +266,7 @@ function handleClose(streams, children, childrenInfo) {
             // Send SIGTERM to alive children
             _.each(aliveChildren, function(child) {
                 if(!isWindows) {
-                    child.kill();
+                    process.kill(-child.pid);
                 } else {
                     spawn('taskkill', ["/pid", child.pid, '/f', '/t']);
                 }

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -41,7 +41,7 @@ describe('concurrently', function() {
     });
 
     it('at least one unsuccessful commands should exit non-zero', function(done) {
-        run('node ./src/main.js "echo" "exit 1" "echo"', {pipe: DEBUG_TESTS})
+        run('node ./src/main.js "echo" "return 1" "echo"', {pipe: DEBUG_TESTS})
         .then(function(exitCode) {
             assert.notStrictEqual(exitCode, 0);
             done();


### PR DESCRIPTION
Since windows doesn't accept signals as unix does, the child processes should be killed in a different way. Also changed so it could be passed on windows. The 'exit 1' command returns 0 on windows.