### PR TITLE
Add an option to kill a tree of child processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options:
   -h, --help                        output usage information
   -V, --version                     output the version number
   -k, --kill-others                 kill other processes if one exits or dies
+  -a, --kill-all                    kill all the descendants of the other processes if one exits or dies
   --no-color                        disable colors from logging
   --names                           names different processes, i.e --name "web,api,hot-server" to be used in the prefix switch
   -p, --prefix <prefix>             prefix used in logging for each process.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concurrently",
-  "version": "2.1.0-dev-fork",
+  "version": "2.1.0-dev",
   "description": "Run commands concurrently",
   "main": "src/main.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concurrently",
-  "version": "2.1.0-dev",
+  "version": "2.1.0-dev-fork",
   "description": "Run commands concurrently",
   "main": "src/main.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-  "name": "concurrently",
-  "version": "2.1.0-dev",
-  "description": "Run commands concurrently",
-  "main": "src/main.js",
-  "bin": {
-    "concurrent": "./src/main.js",
-    "concurrently": "./src/main.js"
-  },
-  "scripts": {
-    "test": "mocha"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/kimmobrunfeldt/concurrently.git"
-  },
-  "keywords": [
-    "bash",
-    "concurrent",
-    "parallel",
-    "concurrently",
-    "command",
-    "sh"
-  ],
-  "author": "Kimmo Brunfeldt",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/kimmobrunfeldt/concurrently/issues"
-  },
-  "homepage": "https://github.com/kimmobrunfeldt/concurrently",
-  "dependencies": {
-    "bluebird": "2.9.6",
-    "chalk": "0.5.1",
-    "commander": "2.6.0",
-    "cross-spawn": "^0.2.9",
-    "lodash": "^4.5.1",
-    "moment": "^2.11.2",
-    "rx": "2.3.24",
-    "tree-kill": "^1.1.0"
-  },
-  "devDependencies": {
-    "chai": "^1.10.0",
-    "mocha": "^2.1.0",
-    "mustache": "^1.0.0",
-    "semver": "^4.2.0",
-    "shell-quote": "^1.4.3",
-    "shelljs": "^0.3.0",
-    "string": "^3.0.0"
-  }
+    "name": "concurrently",
+    "version": "2.1.0-dev",
+    "description": "Run commands concurrently",
+    "main": "src/main.js",
+    "bin": {
+        "concurrent": "./src/main.js",
+        "concurrently": "./src/main.js"
+    },
+    "scripts": {
+        "test": "mocha"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/kimmobrunfeldt/concurrently.git"
+    },
+    "keywords": [
+        "bash",
+        "concurrent",
+        "parallel",
+        "concurrently",
+        "command",
+        "sh"
+    ],
+    "author": "Kimmo Brunfeldt",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/kimmobrunfeldt/concurrently/issues"
+    },
+    "homepage": "https://github.com/kimmobrunfeldt/concurrently",
+    "dependencies": {
+        "bluebird": "2.9.6",
+        "chalk": "0.5.1",
+        "commander": "2.6.0",
+        "cross-spawn": "^0.2.9",
+        "lodash": "^4.5.1",
+        "moment": "^2.11.2",
+        "rx": "2.3.24",
+	"tree-kill": "^1.1.0"
+    },
+    "devDependencies": {
+        "chai": "^1.10.0",
+        "mocha": "^2.1.0",
+        "mustache": "^1.0.0",
+        "semver": "^4.2.0",
+        "shell-quote": "^1.4.3",
+        "shelljs": "^0.3.0",
+        "string": "^3.0.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,49 +1,50 @@
 {
-    "name": "concurrently",
-    "version": "2.1.0-dev",
-    "description": "Run commands concurrently",
-    "main": "src/main.js",
-    "bin": {
-        "concurrent": "./src/main.js",
-        "concurrently": "./src/main.js"
-    },
-    "scripts": {
-        "test": "mocha"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/kimmobrunfeldt/concurrently.git"
-    },
-    "keywords": [
-        "bash",
-        "concurrent",
-        "parallel",
-        "concurrently",
-        "command",
-        "sh"
-    ],
-    "author": "Kimmo Brunfeldt",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/kimmobrunfeldt/concurrently/issues"
-    },
-    "homepage": "https://github.com/kimmobrunfeldt/concurrently",
-    "dependencies": {
-        "bluebird": "2.9.6",
-        "chalk": "0.5.1",
-        "commander": "2.6.0",
-        "cross-spawn": "^0.2.9",
-        "lodash": "^4.5.1",
-        "moment": "^2.11.2",
-        "rx": "2.3.24"
-    },
-    "devDependencies": {
-        "chai": "^1.10.0",
-        "mocha": "^2.1.0",
-        "mustache": "^1.0.0",
-        "semver": "^4.2.0",
-        "shell-quote": "^1.4.3",
-        "shelljs": "^0.3.0",
-        "string": "^3.0.0"
-    }
+  "name": "concurrently",
+  "version": "2.1.0-dev",
+  "description": "Run commands concurrently",
+  "main": "src/main.js",
+  "bin": {
+    "concurrent": "./src/main.js",
+    "concurrently": "./src/main.js"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kimmobrunfeldt/concurrently.git"
+  },
+  "keywords": [
+    "bash",
+    "concurrent",
+    "parallel",
+    "concurrently",
+    "command",
+    "sh"
+  ],
+  "author": "Kimmo Brunfeldt",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kimmobrunfeldt/concurrently/issues"
+  },
+  "homepage": "https://github.com/kimmobrunfeldt/concurrently",
+  "dependencies": {
+    "bluebird": "2.9.6",
+    "chalk": "0.5.1",
+    "commander": "2.6.0",
+    "cross-spawn": "^0.2.9",
+    "lodash": "^4.5.1",
+    "moment": "^2.11.2",
+    "rx": "2.3.24",
+    "tree-kill": "^1.1.0"
+  },
+  "devDependencies": {
+    "chai": "^1.10.0",
+    "mocha": "^2.1.0",
+    "mustache": "^1.0.0",
+    "semver": "^4.2.0",
+    "shell-quote": "^1.4.3",
+    "shelljs": "^0.3.0",
+    "string": "^3.0.0"
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ var program = require('commander');
 var _ = require('lodash');
 var chalk = require('chalk');
 var spawn = Promise.promisifyAll(require('cross-spawn'));
+var kill = require('tree-kill');
 
 var config = {
     // Kill other processes if one dies
@@ -306,7 +307,7 @@ function handleClose(streams, children, childrenInfo) {
 
             // Send SIGTERM to alive children
             _.each(aliveChildren, function(child) {
-                child.kill();
+                kill(child.pid);
             });
         });
     }

--- a/src/main.js
+++ b/src/main.js
@@ -8,11 +8,13 @@ var program = require('commander');
 var _ = require('lodash');
 var chalk = require('chalk');
 var spawn = Promise.promisifyAll(require('cross-spawn'));
-var kill = require('tree-kill');
+var treeKill = require('tree-kill');
 
 var config = {
     // Kill other processes if one dies
     killOthers: false,
+    // and kill all of their children in the tree as well
+    killAll: false,
 
     // How much in ms we wait before killing other processes
     killDelay: 1000,
@@ -67,6 +69,10 @@ function parseArgs() {
         .option(
             '-k, --kill-others',
             'kill other processes if one exits or dies'
+        )
+        .option(
+            '-a, --kill-all',
+            'kill all the descendants of the other processes if one exits or dies'
         )
         .option(
             '--no-color',
@@ -298,7 +304,7 @@ function handleClose(streams, children, childrenInfo) {
         }
     });
 
-    if (config.killOthers) {
+    if (config.killOthers || config.killAll) {
         // Give other processes some time to stop cleanly before killing them
         var delayedExit = closeStream.delay(config.killDelay);
 
@@ -307,7 +313,7 @@ function handleClose(streams, children, childrenInfo) {
 
             // Send SIGTERM to alive children
             _.each(aliveChildren, function(child) {
-                kill(child.pid);
+              config.killAll ? treeKill(child.pid) : child.kill();
             });
         });
     }


### PR DESCRIPTION
This is pretty much essential for working on windows as node will very often spawn via an extra layer of cmd shell - which means that the kill only goes to that and not to the underlying processes.

This may also help with your npm problems as it may be a good idea to take out the whole tree in that case - even on unix.

Given the existence of the tree-kill module the change is straightforward.