### PR TITLE
Send SIGTERM signal instead SIGINT

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -313,7 +313,7 @@ function handleClose(streams, children, childrenInfo) {
                 if (isWindows) {
                     spawn('taskkill', ["/pid", child.pid, '/f', '/t']);
                 } else {
-                    child.kill('SIGINT');
+                    child.kill('SIGTERM');
                 }
             });
         });


### PR DESCRIPTION
On OSX my processes just get killed if I use SIGTERM instead SIGINT. It's also logged `Sending SIGTERM to other processes` so I believe this is the signal supposed to be used.