### PR TITLE
Added ability to set default config in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,48 @@ Examples:
 For more details, visit https://github.com/kimmobrunfeldt/concurrently
 ```
 
+You can also specify configuration options in your `package.json`:
+
+```
+"concurrently": {
+    // Kill other processes if one dies
+    "killOthers": false,
+
+    // How much in ms we wait before killing other processes
+    "killDelay": 1000,
+
+    // Return success or failure of the "first" child to terminate, the "last" child,
+    // or succeed only if "all" children succeed
+    "success": "all",
+
+    // Prefix logging with pid
+    // Possible values: "pid", "none", "time", "command", "index", "name"
+    "prefix": "index",
+
+    // List of custom names to be used in prefix template
+    "names": "",
+
+    // What to split the list of custom names on
+    "nameSeparator": ",",
+
+    // Comma-separated list of chalk color paths to use on prefixes.
+    "prefixColors": "gray.dim",
+
+    // moment format
+    "timestampFormat": "YYYY-MM-DD HH:mm:ss.SSS",
+
+    // How many characters to display from start of command in prefix if
+    // command is defined. Note that also ".." will be added in the middle
+    "prefixLength": 10,
+
+    // By default, color output
+    "color": true,
+
+    // If true, the output will only be raw output of processes, nothing more
+    "raw": false
+}
+```
+
 ## FAQ
 
 * Process exited with code *null*?

--- a/src/main.js
+++ b/src/main.js
@@ -57,6 +57,16 @@ function main() {
     }
 
     try {
+        var rcConfig = require(path.join(process.cwd(), '.concurrentlyrc'));
+
+        if (rcConfig) {
+            config = _.merge(config, rcConfig);
+        }
+    } catch (error) {
+        console.debug(error);
+    }
+
+    try {
         var packageJSON = require(path.join(process.cwd(), 'package.json'));
 
         if (packageJSON && packageJSON.concurrently) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var Rx = require('rx');
+var fs = require('fs');
 var path = require('path');
 var Promise = require('bluebird');
 var moment = require('moment');
@@ -56,16 +57,16 @@ function main() {
         console.error('Warning: "concurrent" command is deprecated, use "concurrently" instead.\n');
     }
 
-    try {
-        var rcConfig = require(path.join(process.cwd(), '.concurrentlyrc'));
+    var rcConfigPath = path.join(process.cwd(), '.concurrentlyrc')
+
+    if (fs.existsSync(rcConfigPath)) {
+        var rcConfig = require();
 
         if (rcConfig) {
             config = _.merge(config, rcConfig);
         }
-    } catch (error) {
-        console.debug(error);
     }
-
+    
     try {
         var packageJSON = require(path.join(process.cwd(), 'package.json'));
 

--- a/src/main.js
+++ b/src/main.js
@@ -59,8 +59,8 @@ function main() {
     try {
         var packageJSON = require(path.join(process.cwd(), 'package.json'));
 
-        if (packageJSON.concurrently) {
-            config = _.merge(config, packageJSON.concurrently;)
+        if (packageJSON && packageJSON.concurrently) {
+            config = _.merge(config, packageJSON.concurrently);
         }
     } catch (error) {
         console.debug(error);

--- a/src/main.js
+++ b/src/main.js
@@ -56,6 +56,16 @@ function main() {
         console.error('Warning: "concurrent" command is deprecated, use "concurrently" instead.\n');
     }
 
+    try {
+        var packageJSON = require(path.join(process.cwd(), 'package.json'));
+
+        if (packageJSON.concurrently) {
+            config = _.merge(config, packageJSON.concurrently;)
+        }
+    } catch (error) {
+        console.debug(error);
+    }
+
     parseArgs();
     config = mergeDefaultsWithArgs(config);
     run(program.args);

--- a/test/support/.concurrentlyrc
+++ b/test/support/.concurrentlyrc
@@ -1,0 +1,3 @@
+{
+  "killOthers": true,
+}

--- a/test/support/package.json
+++ b/test/support/package.json
@@ -1,6 +1,5 @@
 {
   "concurrently": {
-    "killOthers": true,
     "success": "last"
   }
 }

--- a/test/support/package.json
+++ b/test/support/package.json
@@ -1,0 +1,6 @@
+{
+  "concurrently": {
+    "killOthers": true,
+    "success": "last"
+  }
+}

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -69,6 +69,17 @@ describe('concurrently', function() {
             });
     });
 
+    it('package.json config should return last exit code', () => {
+        // When killed, sleep returns null exit code
+        return run('node ./src/main.js "echo test" "sleep 1000"', {
+            pipe: DEBUG_TESTS,
+            cwd: path.join(__dirname, 'support')
+        })
+            .then(function(exitCode) {
+                assert.notStrictEqual(exitCode, 0);
+            });
+    });
+
     it('&& nosuchcmd should return non-zero exit code', () => {
         return run('node ./src/main.js "echo 1 && nosuchcmd" "echo 1 && nosuchcmd" ', {pipe: DEBUG_TESTS})
             .then(function(exitCode) {

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -80,6 +80,17 @@ describe('concurrently', function() {
             });
     });
 
+    it('.concurrentlyrc config should should kill other commands if one dies', () => {
+        // This test would timeout if kill others option does not work
+        return run('node ../../src/main.js "echo test" "sleep 1000"', {
+            pipe: DEBUG_TESTS,
+            cwd: path.join(__dirname, 'support')
+        })
+            .then(function(exitCode) {
+                assert.notStrictEqual(exitCode, 0);
+            });
+    });
+
     it('&& nosuchcmd should return non-zero exit code', () => {
         return run('node ./src/main.js "echo 1 && nosuchcmd" "echo 1 && nosuchcmd" ', {pipe: DEBUG_TESTS})
             .then(function(exitCode) {

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -71,7 +71,7 @@ describe('concurrently', function() {
 
     it('package.json config should return last exit code', () => {
         // When killed, sleep returns null exit code
-        return run('node ./src/main.js "echo test" "sleep 1000"', {
+        return run('node ../../src/main.js "echo test" "sleep 1000"', {
             pipe: DEBUG_TESTS,
             cwd: path.join(__dirname, 'support')
         })


### PR DESCRIPTION
Concurrently is great and I use it a number of times in my `package.json`. However, 99% of the time all the config is the same, so instead of having to repeat myself for every command, I therefore created this PR so that I can keep the config in one place. 

Simply use like this:

```
...
  "concurrently": {
    "killOthers": true,
    "success": "last"
    ...
  }
...
```
