### PR TITLE
Fix unsupported colors throwing errors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -198,7 +198,7 @@ function run(commands) {
 
         if (index < prefixColors.length) {
             var prefixColorPath = prefixColors[index];
-            lastPrefixColor = _.get(chalk, prefixColorPath);
+            lastPrefixColor = _.get(chalk, prefixColorPath, chalk.gray.dim);
         }
 
         var name = index < names.length ? names[index] : '';

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -76,6 +76,13 @@ describe('concurrently', function() {
             });
     });
 
+    it('--prefix-colors should handle non-existent colors without failing', () => {
+        return run('node ./src/main.js -c "not.a.color" "echo colors"', {pipe: DEBUG_TESTS})
+            .then(function(exitCode) {
+                assert.strictEqual(exitCode, 0);
+            });
+    });
+
     ['SIGINT', 'SIGTERM'].forEach((signal) => {
       if (IS_WINDOWS) {
           console.log('IS_WINDOWS=true');


### PR DESCRIPTION
Fix error when a color isn't supported by the current platform. It will revert back to the default "Dim Gray".