### PR TITLE
Drop `bluebird`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/kimmobrunfeldt/concurrently",
   "dependencies": {
-    "bluebird": "2.9.6",
     "chalk": "0.5.1",
     "commander": "2.6.0",
     "lodash": "^4.5.1",

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,6 @@
 
 var Rx = require('rx');
 var path = require('path');
-var Promise = require('bluebird');
 var moment = require('moment');
 var program = require('commander');
 var _ = require('lodash');

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,5 @@
 var childProcess = require('child_process');
 var _ = require('lodash');
-var Promise = require('bluebird');
 var shellQuote = require('shell-quote');
 
 function run(cmd, opts) {


### PR DESCRIPTION
- Promises are native on all versions of `node` that `concurrently` supports
- `bluebird` is only used in [two](https://github.com/kimmobrunfeldt/concurrently/blob/fe1c628efeb4760fe1bf82204142f18aa7a225c1/test/utils.js#L27) [places](https://github.com/kimmobrunfeldt/concurrently/blob/fe1c628efeb4760fe1bf82204142f18aa7a225c1/test/utils.js#L31), both of which are tests