### PR TITLE
Switch from moment to date-fns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Options:
   See https://www.npmjs.com/package/chalk for more information.
   Default: "gray.dim". Example: "black.bgWhite,cyan,gray.dim"
 
-  -t, --timestamp-format <format>  specify the timestamp in moment format. Default: YYYY-MM-DD HH:mm:ss.SSS
+  -t, --timestamp-format <format>  specify the timestamp in moment/date-fns format. Default: YYYY-MM-DD HH:mm:ss.SSS
 
   -r, --raw                        output only raw output of processes, disables prettifying and concurrently coloring
   -s, --success <first|last|all>   Return exit code of zero or one based on the success or failure of the "first" child to terminate, the "last" child, or succeed  only if "all" child processes succeed. Default: all

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "dependencies": {
     "chalk": "0.5.1",
     "commander": "2.6.0",
+    "date-fns": "^1.23.0",
     "lodash": "^4.5.1",
-    "moment": "^2.17.1",
     "rx": "2.3.24",
     "spawn-default-shell": "^2.0.0",
     "tree-kill": "^1.1.0"

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
 
 var Rx = require('rx');
 var path = require('path');
-var moment = require('moment');
+var formatDate = require('date-fns/format');
 var program = require('commander');
 var _ = require('lodash');
 var treeKill = require('tree-kill');
@@ -34,7 +34,7 @@ var config = {
     // Comma-separated list of chalk color paths to use on prefixes.
     prefixColors: 'gray.dim',
 
-    // moment format
+    // moment/date-fns format
     timestampFormat: 'YYYY-MM-DD HH:mm:ss.SSS',
 
     // How many characters to display from start of command in prefix if
@@ -100,7 +100,7 @@ function parseArgs() {
         )
         .option(
             '-t, --timestamp-format <format>',
-            'specify the timestamp in moment format. Default: ' +
+            'specify the timestamp in moment/date-fns format. Default: ' +
             config.timestampFormat + '\n'
         )
         .option(
@@ -353,7 +353,7 @@ function getPrefixes(childrenInfo, child) {
     prefixes.pid = child.pid;
     prefixes.index = childrenInfo[child.pid].index;
     prefixes.name = childrenInfo[child.pid].name;
-    prefixes.time = moment().format(config.timestampFormat);
+    prefixes.time = formatDate(Date.now(), config.timestampFormat);
 
     var command = childrenInfo[child.pid].command;
     prefixes.command = shortenText(command, config.prefixLength);


### PR DESCRIPTION
`date-fns` is modular and about a fifth the size of the very large (and slow) `moment` library.

Usage is the same, as are the tokens ([date-fns](https://date-fns.org/docs/format) / [moment](http://momentjs.com/docs/#/displaying/)).