### PR TITLE
Upgrade spawn-default-shell to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.5.1",
     "moment": "^2.11.2",
     "rx": "2.3.24",
-    "spawn-default-shell": "^1.1.0",
+    "spawn-default-shell": "^2.0.0",
     "tree-kill": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I think we need to upgrade `spawn-default-shell` to `2.0.0` to be able to use `-l` flag and read from `~/.zprofile` 