### PR TITLE
Bump moment.js version to mitigate regexp DoS

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chalk": "0.5.1",
     "commander": "2.6.0",
     "lodash": "^4.5.1",
-    "moment": "^2.11.2",
+    "moment": "^2.17.1",
     "rx": "2.3.24",
     "spawn-default-shell": "^1.1.0",
     "tree-kill": "^1.1.0"


### PR DESCRIPTION
According to auditjs versions < 2.15.2 are vulnerable: https://snyk.io/vuln/npm:moment:20161019