### PR TITLE
Drop CI support for node 0.12, add support for node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - 7
   - 6
   - 4
-  - 0.12
 before_script:
   - npm install -g mocha
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+    - nodejs_version: '7'
     - nodejs_version: '6'
     - nodejs_version: '4'
 install:


### PR DESCRIPTION
Travis jobs for node 0.12 were not passing since #57, and it has also [reached its end of life](https://twitter.com/nodejs/status/814933328893710336), so I removed it from Travis's config.

I also added support for node 7 for both AppVeyor and Travis.