### PR TITLE
Fixes #33 - Add parameter/argument passthrough option

### DIFF
--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -83,6 +83,13 @@ describe('concurrently', function() {
             });
     });
 
+    it('can pass through an argument', () => {
+        return run('node ./src/main.js "exit" -- 1', {pipe: DEBUG_TESTS})
+            .then(function(exitCode) {
+                assert.strictEqual(exitCode, 1);
+            });
+    });
+
     ['SIGINT', 'SIGTERM'].forEach((signal) => {
       if (IS_WINDOWS) {
           console.log('IS_WINDOWS=true');


### PR DESCRIPTION
Use -- to pass through arguments to the first command.

```
concurrently "echo foo" "echo bar" -- baz
```

```
echo foo baz
echo bar
```

Use the -a or --all option to pass through the arguments to all the commands.

```
concurrently "echo foo" "echo bar" --all -- baz
```

```
echo foo baz
echo bar baz
```