### PR TITLE
Default --prefix to "name" when --names is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Examples:
 
  - Custom names and colored prefixes
 
-     $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "npm run watch" "http-server"
+     $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "http-server" "npm run watch"
 
 For more details, visit https://github.com/kimmobrunfeldt/concurrently
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Options:
   --kill-others-on-fail            kill other processes if one exits with non zero status code
   --no-color                       disable colors from logging
   -p, --prefix <prefix>            prefix used in logging for each process.
-  Possible values: index, pid, time, command, name, none, or a template. Default: index. Example template: "{time}-{pid}"
+  Possible values: index, pid, time, command, name, none, or a template. Default: index or name (when --names is set). Example template: "{time}-{pid}"
 
   -n, --names <names>              List of custom names to be used in prefix template.
   Example names: "main,browser,server"
@@ -111,7 +111,7 @@ Examples:
 
  - Custom names and colored prefixes
 
-     $ concurrently --prefix "[{name}]" --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "npm run watch" "http-server"
+     $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "npm run watch" "http-server"
 
 For more details, visit https://github.com/kimmobrunfeldt/concurrently
 ```

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ var config = {
 
     // Prefix logging with pid
     // Possible values: 'pid', 'none', 'time', 'command', 'index', 'name'
-    prefix: 'index',
+    prefix: '',
 
     // List of custom names to be used in prefix template
     names: '',
@@ -58,6 +58,8 @@ function main() {
 
     parseArgs();
     config = mergeDefaultsWithArgs(config);
+    applyDynamicDefaults(config)
+
     run(program.args);
 }
 
@@ -81,7 +83,7 @@ function parseArgs() {
             '-p, --prefix <prefix>',
             'prefix used in logging for each process.\n' +
             'Possible values: index, pid, time, command, name, none, or a template. Default: ' +
-            config.prefix + '. Example template: "{time}-{pid}"\n'
+            'index or name (when --names is set). Example template: "{time}-{pid}"\n'
         )
         .option(
             '-n, --names <names>',
@@ -154,7 +156,7 @@ function parseArgs() {
             '',
             '   - Custom names and colored prefixes',
             '',
-            '       $ concurrently --prefix "[{name}]" --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "npm run watch" "http-server"',
+            '       $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "npm run watch" "http-server"',
             ''
         ];
         console.log(help.join('\n'));
@@ -170,6 +172,12 @@ function parseArgs() {
 function mergeDefaultsWithArgs(config) {
     // This will pollute config object with other attributes from program too
     return _.merge(config, program);
+}
+
+function applyDynamicDefaults(config) {
+    if (!config.prefix) {
+        config.prefix = config.names ? 'name' : 'index';
+    }
 }
 
 function stripCmdQuotes(cmd) {

--- a/src/main.js
+++ b/src/main.js
@@ -156,7 +156,7 @@ function parseArgs() {
             '',
             '   - Custom names and colored prefixes',
             '',
-            '       $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "npm run watch" "http-server"',
+            '       $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "http-server" "npm run watch"',
             ''
         ];
         console.log(help.join('\n'));

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -116,6 +116,48 @@ describe('concurrently', function() {
             });
     });
 
+    it('--prefix should default to "index"', () => {
+        var collectedLines = []
+
+        return run('node ./src/main.js "echo one" "echo two"', {
+            onOutputLine: (line) => {
+                if (/(one|two)$/.exec(line)) {
+                    collectedLines.push(line)
+                }
+            }
+        })
+            .then(function(exitCode) {
+                assert.strictEqual(exitCode, 0);
+
+                collectedLines.sort()
+                assert.deepEqual(collectedLines, [
+                    '[0] one',
+                    '[1] two'
+                ])
+            });
+    });
+
+    it('--names should set a different default prefix', () => {
+        var collectedLines = []
+
+        return run('node ./src/main.js -n aa,bb "echo one" "echo two"', {
+            onOutputLine: (line) => {
+                if (/(one|two)$/.exec(line)) {
+                    collectedLines.push(line)
+                }
+            }
+        })
+            .then(function(exitCode) {
+                assert.strictEqual(exitCode, 0);
+
+                collectedLines.sort()
+                assert.deepEqual(collectedLines, [
+                    '[aa] one',
+                    '[bb] two'
+                ])
+            });
+    });
+
     ['SIGINT', 'SIGTERM'].forEach((signal) => {
       if (IS_WINDOWS) {
           console.log('IS_WINDOWS=true');

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,31 +1,31 @@
 var childProcess = require('child_process');
 var _ = require('lodash');
+var readline = require('readline')
 var shellQuote = require('shell-quote');
+
+// If true, output of commands are shown
+var DEBUG_TESTS = process.env.DEBUG_TESTS === 'true';
 
 function run(cmd, opts) {
     opts = _.merge({
-        pipe: true,
-        cwd: undefined,
-        callback: function(child) {
-            // Since we return promise, we need to provide
-            // this callback if one wants to access the child
-            // process reference
-            // Called immediately after successful child process
-            // spawn
-        }
+        // If set to a function, it will be called for each line
+        // written to the child process's stdout as (line, child)
+        onOutputLine: undefined,
     }, opts);
 
     var child;
     var parts = shellQuote.parse(cmd);
     try {
         child = childProcess.spawn(_.head(parts), _.tail(parts), {
-            cwd: opts.cwd,
-            stdio: opts.pipe ? "inherit" : null
+            stdio: DEBUG_TESTS && !opts.onOutputLine ? 'inherit': null,
         });
     } catch (e) {
         return Promise.reject(e);
     }
-    opts.callback(child);
+
+    if (opts.onOutputLine) {
+        readLines(child, opts.onOutputLine);
+    }
 
     return new Promise(function(resolve, reject) {
         child.on('error', function(err) {
@@ -35,6 +35,21 @@ function run(cmd, opts) {
         child.on('close', function(exitCode) {
             resolve(exitCode);
         });
+    });
+}
+
+function readLines(child, callback) {
+    var rl = readline.createInterface({
+        input: child.stdout,
+        output: null
+    });
+
+    rl.on('line', function(line) {
+        if (DEBUG_TESTS) {
+            console.log(line);
+        }
+
+        callback(line, child)
     });
 }
 


### PR DESCRIPTION
I found it confusing that specifying `--names` without changing the `--prefix` continues to use a default prefix of `index`. This PR changes the default prefix to be `name` when `--names` is set and `index` when it's not.

It also cleans up the test code; since this adds new tests that use `readline`, I moved that functionality into `tests/utils.js`.

(cf: kimmobrunfeldt/concurrently#53)