### PR TITLE
Add --sigkill option to use sigkill instead of sigterm

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -74,6 +74,10 @@ function parseArgs() {
             'kill other processes if one exits with non zero status code'
         )
         .option(
+            '--sigkill',
+            'Use SIGKILL instead of SIGTERM for killing remaining processes'
+        )
+        .option(
             '--no-color',
             'disable colors from logging'
         )
@@ -311,7 +315,10 @@ function killOtherProcesses(processes) {
 
     // Send SIGTERM to alive children
     _.each(processes, function(child) {
-        treeKill(child.pid, 'SIGTERM');
+        var signal = config.sigkill ?
+            'SIGKILL' :
+            'SIGTERM';
+        treeKill(child.pid, signal);
     });
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -311,14 +311,20 @@ function handleClose(streams, children, childrenInfo) {
 }
 
 function killOtherProcesses(processes) {
-    logEvent('--> ', chalk.gray.dim, 'Sending SIGTERM to other processes..');
+    var signal = config.sigkill ?
+        'SIGKILL' :
+        'SIGTERM';
+    logEvent('--> ', chalk.gray.dim, 'Sending ' + signal + ' to other processes..');
 
+    var count = 0;
     // Send SIGTERM to alive children
     _.each(processes, function(child) {
-        var signal = config.sigkill ?
-            'SIGKILL' :
-            'SIGTERM';
-        treeKill(child.pid, signal);
+        treeKill(child.pid, signal, function () {
+            count++;
+            if (count === processes.length) {
+                process.exit(0);
+            }
+        });
     });
 }
 


### PR DESCRIPTION
Also, exit the `concurrently` process when all the signals have been sent.