### PR TITLE
Npm run shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ In package.json, escape quotes:
 "start": "concurrently \"command1 arg\" \"command2 arg\""
 ```
 
+NPM run commands can be shortened:
+
+```bash
+concurrently "npm:watch-js" "npm:watch-css" "npm:watch-node"
+
+# Equivalent to:
+concurrently -n watch-js,watch-css,watch-node "npm run watch-js" "npm run watch-css" "npm run watch-node"
+```
+
 Good frontend one-liner example [here](https://github.com/kimmobrunfeldt/dont-copy-paste-this-frontend-template/blob/5cd2bde719654941bdfc0a42c6f1b8e69ae79980/package.json#L9).
 
 Help:
@@ -117,6 +126,10 @@ Examples:
  - Custom names and colored prefixes
 
      $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "http-server" "npm run watch"
+
+ - Shortened NPM run commands
+
+     $ concurrently npm:watch-node npm:watch-js npm:watch-css
 
 For more details, visit https://github.com/kimmobrunfeldt/concurrently
 ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "node": ">=4.0.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "echo": "echo",
+    "echo-test": "echo test"
   },
   "repository": {
     "type": "git",

--- a/src/main.js
+++ b/src/main.js
@@ -185,6 +185,10 @@ function parseArgs() {
             '   - Custom names and colored prefixes',
             '',
             '       $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "http-server" "npm run watch"',
+            '',
+            '   - Shortened NPM run commands',
+            '',
+            '       $ concurrently npm:watch-node npm:watch-js npm:watch-css',
             ''
         ];
         console.log(help.join('\n'));

--- a/src/main.js
+++ b/src/main.js
@@ -69,7 +69,8 @@ function main() {
     config = mergeDefaultsWithArgs(config);
     applyDynamicDefaults(config)
 
-    run(program.args);
+    var cmds = program.args.map(stripCmdQuotes).map(expandCmdShortcuts);
+    run(cmds);
 }
 
 function parseArgs() {
@@ -213,14 +214,21 @@ function stripCmdQuotes(cmd) {
     }
 }
 
+function expandCmdShortcuts(cmd) {
+    let shortcut = cmd.match(/^npm:(\S+)(.*)/);
+    if (shortcut) {
+        return `npm run ${shortcut[1]}${shortcut[2]}`;
+    }
+
+    return cmd;
+}
+
 function run(commands) {
     var childrenInfo = {};
     var lastPrefixColor = _.get(chalk, chalk.gray.dim);
     var prefixColors = config.prefixColors.split(',');
     var names = config.names.split(config.nameSeparator);
     var children = _.map(commands, function(cmd, index) {
-        // Remove quotes.
-        cmd = stripCmdQuotes(cmd);
 
         var spawnOpts = config.raw ? {stdio: 'inherit'} : {};
         if (IS_WINDOWS) {

--- a/src/main.js
+++ b/src/main.js
@@ -216,7 +216,7 @@ function stripCmdQuotes(cmd) {
 }
 
 function expandCmdShortcuts(cmd, idx, names) {
-    let shortcut = cmd.match(/^npm:(\S+)(.*)/);
+    var shortcut = cmd.match(/^npm:(\S+)(.*)/);
     if (shortcut) {
         if (!names[idx]) {
             names[idx] = shortcut[1];

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -275,9 +275,9 @@ describe('concurrently', function() {
         var echo2 = false;
         run('node ./src/main.js "npm:echo-test" "npm:echo -- testarg"', {
             onOutputLine: function (line, child) {
-                if (line === '[0] test') {
+                if (line === '[echo-test] test') {
                     echo1 = true;
-                } else if (line === '[1] testarg') {
+                } else if (line === '[echo] testarg') {
                     echo2 = true;
                 }
             }

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -269,6 +269,26 @@ describe('concurrently', function() {
         });
       });
     });
+
+    it('should expand npm: command shortcuts', (done) => {
+        var echo1 = false;
+        var echo2 = false;
+        run('node ./src/main.js "npm:echo-test" "npm:echo -- testarg"', {
+            onOutputLine: function (line, child) {
+                if (line === '[0] test') {
+                    echo1 = true;
+                } else if (line === '[1] testarg') {
+                    echo2 = true;
+                }
+            }
+        })
+        .then((exitCode) => {
+            assert.strictEqual(exitCode, 0);
+            assert.ok(echo1);
+            assert.ok(echo2);
+        })
+        .then(done, done);
+    });
 });
 
 function resolve(relativePath) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -11,6 +11,7 @@ function run(cmd, opts) {
         // If set to a function, it will be called for each line
         // written to the child process's stdout as (line, child)
         onOutputLine: undefined,
+        onErrorLine: undefined
     }, opts);
 
     var child;
@@ -27,6 +28,10 @@ function run(cmd, opts) {
         readLines(child, opts.onOutputLine);
     }
 
+    if (opts.onErrorLine) {
+        readLines(child, opts.onErrorLine, 'stderr');
+    }
+
     return new Promise(function(resolve, reject) {
         child.on('error', function(err) {
             reject(err);
@@ -38,9 +43,10 @@ function run(cmd, opts) {
     });
 }
 
-function readLines(child, callback) {
+function readLines(child, callback, src) {
+    src = src || 'stdout';
     var rl = readline.createInterface({
-        input: child.stdout,
+        input: child[src],
         output: null
     });
 


### PR DESCRIPTION
Allow `npm run` commands to be shortened by having a command with the pattern `npm:cmd` expand to `npm run cmd` and set the default name (and prefix) for that process to `cmd`.

Possible solution for #46.