### PR TITLE
Removed brackets and spacing for --prefix none

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -441,7 +441,7 @@ function getPrefix(childrenInfo, child) {
     var prefixes = getPrefixes(childrenInfo, child);
     var prefixType = config.prefix || prefixes.name ? 'name' : 'index';
     if (_.includes(_.keys(prefixes), prefixType)) {
-        var prefix =prefixes[prefixType];
+        var prefix = prefixes[prefixType];
 
         if (!prefix) {
             return prefix;

--- a/src/main.js
+++ b/src/main.js
@@ -525,7 +525,7 @@ function logWithPrefix(prefix, prefixColor, text, color) {
     });
 
     if (!lastChar || lastChar == '\n' ){
-        process.stdout.write(coloredPrefix);
+        process.stdout.write(`${coloredPrefix}`);
     }
 
     lastChar = text[text.length - 1];

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ var config = {
 
     // Prefix logging with pid
     // Possible values: 'pid', 'none', 'time', 'command', 'index', 'name'
-    prefix: '',
+    prefix: undefined,
 
     // List of custom names to be used in prefix template
     names: '',
@@ -434,10 +434,20 @@ function colorText(text, color) {
 }
 
 function getPrefix(childrenInfo, child) {
+    if (config.prefix === '') {
+        return ''
+    }
+
     var prefixes = getPrefixes(childrenInfo, child);
     var prefixType = config.prefix || prefixes.name ? 'name' : 'index';
     if (_.includes(_.keys(prefixes), prefixType)) {
-        return '[' + prefixes[prefixType] + '] ';
+        var prefix =prefixes[prefixType];
+
+        if (!prefix) {
+            return prefix;
+        }
+
+        return '[' + prefix + '] ';
     }
 
     return _.reduce(prefixes, function(memo, val, key) {
@@ -503,7 +513,9 @@ function logWithPrefix(prefix, prefixColor, text, color) {
 
     var lines = text.split('\n');
     // Do not bgColor trailing space
-    var coloredPrefix = colorText(prefix.replace(/ $/, ''), prefixColor) + ' ';
+    var coloredPrefix = prefix
+        ? colorText(prefix.replace(/ $/, ''), prefixColor) + ' '
+        : prefix;
     var paddedLines = _.map(lines, function(line, index) {
         var coloredLine = color ? colorText(line, color) : line;
         if (index !== 0 && index !== (lines.length - 1)) {

--- a/src/main.js
+++ b/src/main.js
@@ -515,7 +515,7 @@ function logWithPrefix(prefix, prefixColor, text, color) {
     // Do not bgColor trailing space
     var coloredPrefix = prefix
         ? colorText(prefix.replace(/ $/, ''), prefixColor) + ' '
-        : prefix;
+        : prefix + '';
     var paddedLines = _.map(lines, function(line, index) {
         var coloredLine = color ? colorText(line, color) : line;
         if (index !== 0 && index !== (lines.length - 1)) {
@@ -525,7 +525,7 @@ function logWithPrefix(prefix, prefixColor, text, color) {
     });
 
     if (!lastChar || lastChar == '\n' ){
-        process.stdout.write(`${coloredPrefix}`);
+        process.stdout.write(coloredPrefix);
     }
 
     lastChar = text[text.length - 1];

--- a/src/main.js
+++ b/src/main.js
@@ -443,7 +443,7 @@ function getPrefix(childrenInfo, child) {
     if (_.includes(_.keys(prefixes), prefixType)) {
         var prefix = prefixes[prefixType];
 
-        if (!prefix) {
+        if (prefix === undefined) {
             return prefix;
         }
 

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -150,7 +150,9 @@ describe('concurrently', function() {
 
                 assert.deepEqual(collectedLines, [
                     'one',
-                    'two'
+                    'two',
+                    'echo two exited with code 0',
+                    'echo one exited with code 0'
                 ]);
             });
     });

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -137,6 +137,24 @@ describe('concurrently', function() {
             });
     });
 
+    it('--prefix should not display if prefix is empty', () => {
+        var collectedLines = []
+
+        return run('node ./src/main.js "echo one" "echo two" --prefix ""', {
+            onOutputLine: (line) => {
+                collectedLines.push(line)
+            }
+        })
+            .then(function(exitCode) {
+                assert.strictEqual(exitCode, 0);
+
+                assert.deepEqual(collectedLines, [
+                    'one',
+                    'two'
+                ]);
+            });
+    });
+
     it('--names should set a different default prefix', () => {
         var collectedLines = []
 


### PR DESCRIPTION
Now, the wrapping []s and spaces are only added if the prefix resolves to something other than an empty string.

Fixes #123