### PR TITLE
Add support for yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,25 +225,25 @@ For more details, visit https://github.com/kimmobrunfeldt/concurrently
 concurrently can be used programmatically by using the API documented below:
 
 ### `concurrently(commands[, options])`
-- `commands`: an array of either strings (containing the commands to run) or objects 
+- `commands`: an array of either strings (containing the commands to run) or objects
   with the shape `{ command, name, prefixColor }`.
 - `options` (optional): an object containing any of the below:
-    - `defaultInputTarget`: the default input target when reading from `inputStream`. 
+    - `defaultInputTarget`: the default input target when reading from `inputStream`.
     Default: `0`.
-    - `inputStream`: a [`Readable` stream](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_readable_streams) 
+    - `inputStream`: a [`Readable` stream](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_readable_streams)
     to read the input from, eg `process.stdin`.
-    - `killOthers`: an array of exitting conditions that will cause a process to kill others.  
+    - `killOthers`: an array of exitting conditions that will cause a process to kill others.
     Can contain any of `success` or `failure`.
     - `outputStream`: a [`Writable` stream](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_writable_streams)
     to write logs to. Default: `process.stdout`.
-    - `prefix`: the prefix type to use when logging processes output.  
-      Possible values: `index`, `pid`, `time`, `command`, `name`, `none`, or a template (eg `[{time} process: {pid}]`).  
+    - `prefix`: the prefix type to use when logging processes output.
+      Possible values: `index`, `pid`, `time`, `command`, `name`, `none`, or a template (eg `[{time} process: {pid}]`).
       Default: the name of the process, or its index if no name is set.
     - `prefixLength`: how many characters to show when prefixing with `command`. Default: `10`
     - `raw`: whether raw mode should be used, meaning strictly process output will
     be logged, without any prefixes, colouring or extra stuff.
     - `successCondition`: the condition to consider the run was successful.
-    If `first`, only the first process will make up the success of the run; if `last`, the last.  
+    If `first`, only the first process will make up the success of the run; if `last`, the last.
     Anything else means all processes should exit successfully.
     - `restartTries`: how many attempts to restart a process that dies will be made. Default: `0`.
     - `restartDelay`: how many milliseconds to wait between process restarts. Default: `0`.
@@ -258,7 +258,7 @@ Example:
 ```js
 const concurrently = require('concurrently');
 concurrently([
-    'npm:watch-*', 
+    'npm:watch-*',
     { command: 'nodemon', name: 'server' }
 ], {
     prefix: 'name',
@@ -282,3 +282,6 @@ concurrently([
     So *null* means the process didn't terminate normally. This will make **concurrent**
     to return non-zero exit code too.
 
+* Does this work with the npm-replacement [yarn](https://github.com/yarnpkg/yarn)?
+
+    Yes! In all examples above, you may replace "`npm`" with "`yarn`".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concurrently",
-  "version": "4.1.1",
+  "version": "4.0.1",
   "description": "Run commands concurrently",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concurrently",
-  "version": "4.0.1",
+  "version": "4.1.1",
   "description": "Run commands concurrently",
   "main": "index.js",
   "bin": {

--- a/src/command-parser/expand-npm-shortcut.js
+++ b/src/command-parser/expand-npm-shortcut.js
@@ -1,13 +1,13 @@
 module.exports = class ExpandNpmShortcut {
     parse(commandInfo) {
-        const [, cmdName, args] = commandInfo.command.match(/^npm:(\S+)(.*)/) || [];
+        const [, npmCmd, cmdName, args] = commandInfo.command.match(/^(npm|yarn):(\S+)(.*)/) || [];
         if (!cmdName) {
             return commandInfo;
         }
 
         return Object.assign({}, commandInfo, {
             name: commandInfo.name || cmdName,
-            command: `npm run ${cmdName}${args}`
+            command: `${npmCmd} run ${cmdName}${args}`
         });
     }
 };

--- a/src/command-parser/expand-npm-shortcut.spec.js
+++ b/src/command-parser/expand-npm-shortcut.spec.js
@@ -9,25 +9,28 @@ it('returns same command if no npm: prefix is present', () => {
     expect(parser.parse(commandInfo)).toBe(commandInfo);
 });
 
-describe('with npm: prefix', () => {
-    it('expands to "npm run <script> <args>"', () => {
-        const commandInfo = {
-            name: 'echo',
-            command: 'npm:foo -- bar'
-        };
-        expect(parser.parse(commandInfo)).toEqual({
-            name: 'echo',
-            command: 'npm run foo -- bar'
+for (const npmCmd of ['npm', 'yarn']) {
+    describe(`with ${npmCmd}: prefix`, () => {
+        it(`expands to "${npmCmd} run <script> <args>"`, () => {
+            const commandInfo = {
+                name: 'echo',
+                command: `${npmCmd}:foo -- bar`
+            };
+            expect(parser.parse(commandInfo)).toEqual({
+                name: 'echo',
+                command: `${npmCmd} run foo -- bar`
+            });
+        });
+
+        it('sets name to script name if none', () => {
+            const commandInfo = {
+                command: `${npmCmd}:foo -- bar`
+            };
+            expect(parser.parse(commandInfo)).toEqual({
+                name: 'foo',
+                command: `${npmCmd} run foo -- bar`
+            });
         });
     });
 
-    it('sets name to script name if none', () => {
-        const commandInfo = {
-            command: 'npm:foo -- bar'
-        };
-        expect(parser.parse(commandInfo)).toEqual({
-            name: 'foo',
-            command: 'npm run foo -- bar'
-        });
-    });
-});
+}

--- a/src/command-parser/expand-npm-wildcard.js
+++ b/src/command-parser/expand-npm-wildcard.js
@@ -7,7 +7,7 @@ module.exports = class ExpandNpmWildcard {
     }
 
     parse(commandInfo) {
-        const [, cmdName, args] = commandInfo.command.match(/npm run (\S+)([^&]*)/) || [];
+        const [, npmCmd, cmdName, args] = commandInfo.command.match(/(npm|yarn) run (\S+)([^&]*)/) || [];
         const wildcardPosition = (cmdName || '').indexOf('*');
 
         // If the regex didn't match an npm script, or it has no wildcard,
@@ -27,7 +27,7 @@ module.exports = class ExpandNpmWildcard {
         return this.scripts
             .filter(script => wildcardRegex.test(script))
             .map(script => Object.assign({}, commandInfo, {
-                command: `npm run ${script}${args}`,
+                command: `${npmCmd} run ${script}${args}`,
                 name: script
             }));
     }


### PR DESCRIPTION
Hello 👋. I wasn't sure what the interest level is in this, so I just put together a PR to demonstrate it. My organization uses yarn instead of npm, and this makes `concurrently` more useful to us.

This adds support for the popular [npm replacement, yarn](https://github.com/yarnpkg/yarn).

```bash
ian $ grep watch package.json
    "watch-compile": "node ./scripts/compile-watch.js",
    "watch-generate-client": "node ./scripts/generate-client-watch.js",
    "dev": "yarn compile && concurrently 'yarn compile-watch' 'yarn generate-client-watch'",

ian $ concurrently "yarn:watch-*"
yarn run v1.10.1
yarn run v1.10.1
$ node ./scripts/generate-client-watch.js
$ node ./scripts/compile-watch.js
[watch-generate-client] Watching /Users/ian/workspace/interface/**/*.proto for changes.
[watch-compile] 10:57:39 - Starting compilation in watch mode...
[watch-compile] 10:57:41 - Found 0 errors. Watching for file changes.
[watch-generate-client] Interface file changed: rpc_interface.proto
[watch-generate-client]   Generating: /Users/ian/workspace/client-generated/generated-schema.json
[watch-generate-client]   Generating: /Users/ian/workspace/client-generated/generated-client.js
[watch-generate-client]   Generating: /Users/ian/workspace/client-generated/generated-client.d.ts
[watch-generate-client]   Generating: /Users/ian/workspace/client-generated/package.json
[watch-generate-client]   Generating: /Users/ian/workspace/client-generated/index.ts
[watch-compile] 10:57:44 - File change detected. Starting incremental compilation...
[watch-compile] 10:57:44 - Found 0 errors. Watching for file changes.
```