### PR TITLE
Allow different env vars for each command

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ const concurrently = require('concurrently');
 concurrently([
     'npm:watch-*',
     { command: 'nodemon', name: 'server' },
-    { command: 'deploy', name: 'deploy', env: {PUBLIC_KEY: '...'} }
+    { command: 'deploy', name: 'deploy', env: { PUBLIC_KEY: '...' } }
 ], {
     prefix: 'name',
     killOthers: ['failure', 'success'],

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ concurrently can be used programmatically by using the API documented below:
 
 ### `concurrently(commands[, options])`
 - `commands`: an array of either strings (containing the commands to run) or objects
-  with the shape `{ command, name, prefixColor }`.
+  with the shape `{ command, name, prefixColor, env }`.
 - `options` (optional): an object containing any of the below:
     - `defaultInputTarget`: the default input target when reading from `inputStream`.
     Default: `0`.
@@ -259,7 +259,8 @@ Example:
 const concurrently = require('concurrently');
 concurrently([
     'npm:watch-*',
-    { command: 'nodemon', name: 'server' }
+    { command: 'nodemon', name: 'server' },
+    { command: 'deploy', name: 'deploy', env: {PUBLIC_KEY: '...'} }
 ], {
     prefix: 'name',
     killOthers: ['failure', 'success'],

--- a/src/concurrently.spec.js
+++ b/src/concurrently.spec.js
@@ -75,3 +75,22 @@ it('passes commands wrapped from a controller to the next one', () => {
 
     expect(fakeCommand.start).toHaveBeenCalledTimes(1);
 });
+
+it('merges extra env vars into each command', () => {
+    create([
+        { command: 'echo', env: { foo: 'bar' } },
+        { command: 'echo', env: { foo: 'baz' } },
+        'kill'
+    ]);
+    
+    expect(spawn).toHaveBeenCalledTimes(3);
+    expect(spawn).toHaveBeenCalledWith('echo', expect.objectContaining({
+        env: expect.objectContaining({ foo: 'bar' }) 
+    }));
+    expect(spawn).toHaveBeenCalledWith('echo', expect.objectContaining({
+        env: expect.objectContaining({ foo: 'baz' }) 
+    }));
+    expect(spawn).toHaveBeenCalledWith('kill', expect.objectContaining({
+        env: expect.not.objectContaining({ foo: expect.anything() }) 
+    }));
+});

--- a/src/get-spawn-opts.js
+++ b/src/get-spawn-opts.js
@@ -3,10 +3,11 @@ const supportsColor = require('supports-color');
 module.exports = ({
     colorSupport = supportsColor,
     process = global.process,
-    raw = false
+    raw = false,
+    env = {}
 } = {}) => Object.assign(
     {},
     raw && { stdio: 'inherit' },
     /^win/.test(process.platform) && { detached: false },
-    colorSupport && { env: Object.assign({ FORCE_COLOR: colorSupport.level }, process.env) }
+    colorSupport && { env: Object.assign({ FORCE_COLOR: colorSupport.level }, process.env, env) }
 );

--- a/src/get-spawn-opts.js
+++ b/src/get-spawn-opts.js
@@ -9,5 +9,5 @@ module.exports = ({
     {},
     raw && { stdio: 'inherit' },
     /^win/.test(process.platform) && { detached: false },
-    colorSupport && { env: Object.assign({ FORCE_COLOR: colorSupport.level }, process.env, env) }
+    { env: Object.assign(colorSupport ? { FORCE_COLOR: colorSupport.level } : {}, process.env, env) }
 );

--- a/src/get-spawn-opts.spec.js
+++ b/src/get-spawn-opts.spec.js
@@ -10,7 +10,7 @@ it('sets stdio to inherit when raw', () => {
 
 it('merges FORCE_COLOR into env vars if color supported', () => {
     const process = { env: { foo: 'bar' } };
-    expect(getSpawnOpts({ process, colorSupport: false }).env).toBeUndefined();
+    expect(getSpawnOpts({ process, colorSupport: false }).env).toEqual(process.env);
     expect(getSpawnOpts({ process, colorSupport: { level: 1 } }).env).toEqual({
         FORCE_COLOR: 1,
         foo: 'bar'


### PR DESCRIPTION
This allows you to pass different environment variables to each command.

This PR adds an optional `env` property to the commands object.

The values on the env object take precedence over `process.env` so it can override any global environment variables that may have been set earlier.