### PR TITLE
upgrade date-fns to v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Prefix styling
                           prefix when it is set to "command"
                                                           [number] [default: 10]
   -t, --timestamp-format  Specify the timestamp in moment/date-fns format.
-                                   [string] [default: "YYYY-MM-DD HH:mm:ss.SSS"]
+                                   [string] [default: "yyyy-MM-dd HH:mm:ss.SSS"]
 
 Input handling
   -i, --handle-input      Whether input should be forwarded to the child
@@ -247,8 +247,8 @@ concurrently can be used programmatically by using the API documented below:
     Anything else means all processes should exit successfully.
     - `restartTries`: how many attempts to restart a process that dies will be made. Default: `0`.
     - `restartDelay`: how many milliseconds to wait between process restarts. Default: `0`.
-    - `timestampFormat`: a [date-fns/moment format](https://date-fns.org/v1.29.0/docs/format)
-    to use when prefixing with `time`. Default: `YYYY-MM-DD HH:mm:ss.ZZZ`
+    - `timestampFormat`: a [date-fns format](https://date-fns.org/v2.0.1/docs/format)
+    to use when prefixing with `time`. Default: `yyyy-MM-dd HH:mm:ss.ZZZ`
 
 > Returns: a `Promise` that resolves if the run was successful (according to `successCondition` option),
 > or rejects otherwise.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1114,9 +1114,9 @@
       }
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.1.tgz",
+      "integrity": "sha512-C14oTzTZy8DH1Eq8N78owrCWvf3+cnJw88BTK/N3DYWVxDJuJzPaNdplzYxDYuuXXGvqBcO4Vy5SOrwAooXSWw=="
     },
     "debug": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^2.4.2",
-    "date-fns": "^1.30.1",
+    "date-fns": "^2.0.1",
     "lodash": "^4.17.15",
     "read-pkg": "^4.0.1",
     "rxjs": "^6.5.2",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -22,6 +22,6 @@ module.exports = {
     restartDelay: 0,
     // Condition of success for concurrently itself.
     success: 'all',
-    // Refer to https://date-fns.org/v1.29.0/docs/format
-    timestampFormat: 'YYYY-MM-DD HH:mm:ss.SSS'
+    // Refer to https://date-fns.org/v2.0.1/docs/format
+    timestampFormat: 'yyyy-MM-dd HH:mm:ss.SSS'
 };

--- a/src/logger.spec.js
+++ b/src/logger.spec.js
@@ -111,7 +111,7 @@ describe('#logCommandText()', () => {
     });
 
     it('logs with prefixFormat set to time (with timestampFormat)', () => {
-        const logger = createLogger({ prefixFormat: 'time', timestampFormat: 'YYYY' });
+        const logger = createLogger({ prefixFormat: 'time', timestampFormat: 'yyyy' });
         logger.logCommandText('foo', {});
 
         const year = new Date().getFullYear();


### PR DESCRIPTION
[`date-fns@2` has been released](https://github.com/date-fns/date-fns/releases/tag/v2.0.0), and since `concurrently` is pinned on `^1.x.x`, it makes it hard for users `concurrently` to use `date-fns@2` simultaneously, due to conflicting packages.

This PR updates this dependency.

Note that this is a breaking change in `concurrently` for users who may have passed an invalid format (which previously worked) due to [a breaking change in `date-fns@2.0.0`, to better conform the unicode standard](https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md)