### PR TITLE
Return exitCodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ concurrently can be used programmatically by using the API documented below:
     to use when prefixing with `time`. Default: `yyyy-MM-dd HH:mm:ss.ZZZ`
 
 > Returns: a `Promise` that resolves if the run was successful (according to `successCondition` option),
-> or rejects otherwise.
+> or rejects, containing an array with the exit codes of each command that has been run.
 
 Example:
 

--- a/src/completion-listener.spec.js
+++ b/src/completion-listener.spec.js
@@ -9,10 +9,11 @@ beforeEach(() => {
     scheduler = new TestScheduler();
 });
 
-const createController = successCondition => new CompletionListener({
-    successCondition,
-    scheduler
-});
+const createController = successCondition =>
+    new CompletionListener({
+        successCondition,
+        scheduler
+    });
 
 describe('with default success condition set', () => {
     it('succeeds if all processes exited with code 0', () => {
@@ -23,7 +24,7 @@ describe('with default success condition set', () => {
 
         scheduler.flush();
 
-        return expect(result).resolves.toBeNull();
+        return expect(result).resolves.toEqual([0, 0]);
     });
 
     it('fails if one of the processes exited with non-0 code', () => {
@@ -34,10 +35,9 @@ describe('with default success condition set', () => {
 
         scheduler.flush();
 
-        expect(result).rejects.toThrowError();
+        expect(result).rejects.toEqual([0, 1]);
     });
 });
-
 
 describe('with success condition set to first', () => {
     it('succeeds if first process to exit has code 0', () => {
@@ -48,7 +48,7 @@ describe('with success condition set to first', () => {
 
         scheduler.flush();
 
-        return expect(result).resolves.toBeNull();
+        return expect(result).resolves.toEqual([0, 1]);
     });
 
     it('fails if first process to exit has non-0 code', () => {
@@ -59,7 +59,7 @@ describe('with success condition set to first', () => {
 
         scheduler.flush();
 
-        return expect(result).rejects.toThrowError();
+        return expect(result).rejects.toEqual([1, 0]);
     });
 });
 
@@ -72,7 +72,7 @@ describe('with success condition set to last', () => {
 
         scheduler.flush();
 
-        return expect(result).resolves.toBeNull();
+        return expect(result).resolves.toEqual([1, 0]);
     });
 
     it('fails if last process to exit has non-0 code', () => {
@@ -83,6 +83,6 @@ describe('with success condition set to last', () => {
 
         scheduler.flush();
 
-        return expect(result).rejects.toThrowError();
+        return expect(result).rejects.toEqual([0, 1]);
     });
 });


### PR DESCRIPTION
Return the exit codes on success or failures so it can be easily used by the caller.
My use case is to display a clear message showing which command failed at the end of the execution.