### PR TITLE
Support limit of processes at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,18 +113,21 @@ Help:
 concurrently [options] <command ...>
 
 General
-  -n, --names       List of custom names to be used in prefix template.
-                    Example names: "main,browser,server"                [string]
-  --name-separator  The character to split <names> on. Example usage:
-                    concurrently -n "styles|scripts|server" --name-separator "|"
-                                                                  [default: ","]
-  -r, --raw         Output only raw output of processes, disables prettifying
-                    and concurrently coloring.                         [boolean]
-  -s, --success     Return exit code of zero or one based on the success or
-                    failure of the "first" child to terminate, the "last child",
-                    or succeed only if "all" child processes succeed.
+  -m, --max-processes  How many processes should run at once.
+                       New processes only spawn after all restart tries of a
+                       process.                                         [number]
+  -n, --names          List of custom names to be used in prefix template.
+                       Example names: "main,browser,server"             [string]
+  --name-separator     The character to split <names> on. Example usage:
+                       concurrently -n "styles|scripts|server" --name-separator
+                       "|"                                        [default: ","]
+  -r, --raw            Output only raw output of processes, disables prettifying
+                       and concurrently coloring.                      [boolean]
+  -s, --success        Return exit code of zero or one based on the success or
+                       failure of the "first" child to terminate, the "last
+                       child", or succeed only if "all" child processes succeed.
                               [choices: "first", "last", "all"] [default: "all"]
-  --no-color        Disables colors from logging                       [boolean]
+  --no-color           Disables colors from logging                    [boolean]
 
 Prefix styling
   -p, --prefix            Prefix used in logging for each process.
@@ -230,6 +233,7 @@ concurrently can be used programmatically by using the API documented below:
     to read the input from, eg `process.stdin`.
     - `killOthers`: an array of exitting conditions that will cause a process to kill others.
     Can contain any of `success` or `failure`.
+    - `maxProcesses`: how many processes should run at once.
     - `outputStream`: a [`Writable` stream](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_writable_streams)
     to write logs to. Default: `process.stdout`.
     - `prefix`: the prefix type to use when logging processes output.

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -13,6 +13,13 @@ const args = yargs
     .alias('v', 'version')
     .options({
         // General
+        'm': {
+            alias: 'max-processes',
+            describe:
+                'How many processes should run at once.\n' +
+                'New processes only spawn after all restart tries of a process.',
+            type: 'number'
+        },
         'n': {
             alias: 'names',
             describe:
@@ -125,7 +132,7 @@ const args = yargs
                 'Can be either the index or the name of the process.'
         }
     })
-    .group(['n', 'name-separator', 'raw', 's', 'no-color'], 'General')
+    .group(['m', 'n', 'name-separator', 'raw', 's', 'no-color'], 'General')
     .group(['p', 'c', 'l', 't'], 'Prefix styling')
     .group(['i', 'default-input-target'], 'Input handling')
     .group(['k', 'kill-others-on-fail'], 'Killing other processes')
@@ -152,6 +159,7 @@ concurrently(args._.map((command, index) => {
     killOthers: args.killOthers
         ? ['success', 'failure']
         : (args.killOthersOnFail ? ['failure'] : []),
+    maxProcesses: args.maxProcesses,
     raw: args.raw,
     prefix: args.prefix,
     prefixLength: args.prefixLength,

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = (commands, options = {}) => {
                 defaultInputTarget: options.defaultInputTarget,
                 inputStream: options.inputStream,
             }),
-            new KillOnSignal(),
+            new KillOnSignal({ process }),
             new RestartProcess({
                 logger,
                 delay: options.restartDelay,

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = (commands, options = {}) => {
     });
 
     return concurrently(commands, {
+        maxProcesses: options.maxProcesses,
         raw: options.raw,
         successCondition: options.successCondition,
         controllers: [

--- a/src/concurrently.spec.js
+++ b/src/concurrently.spec.js
@@ -1,5 +1,4 @@
 const EventEmitter = require('events');
-const { Writable } = require('stream');
 
 const createFakeCommand = require('./flow-control/fixtures/fake-command');
 const concurrently = require('./concurrently');

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -8,6 +8,8 @@ module.exports = {
     defaultInputTarget: 0,
     // Whether process.stdin should be forwarded to child processes
     handleInput: false,
+    // How many processes to run at once
+    maxProcesses: 0,
     nameSeparator: ',',
     // Which prefix style to use when logging processes output.
     prefix: '',

--- a/src/flow-control/kill-on-signal.js
+++ b/src/flow-control/kill-on-signal.js
@@ -2,7 +2,7 @@ const { map } = require('rxjs/operators');
 
 
 module.exports = class KillOnSignal {
-    constructor({ process = global.process } = {}) {
+    constructor({ process }) {
         this.process = process;
     }
 

--- a/src/get-spawn-opts.js
+++ b/src/get-spawn-opts.js
@@ -4,7 +4,7 @@ module.exports = ({
     colorSupport = supportsColor.stdout,
     process = global.process,
     raw = false
-} = {}) => Object.assign(
+}) => Object.assign(
     {},
     raw && { stdio: 'inherit' },
     /^win/.test(process.platform) && { detached: false },


### PR DESCRIPTION
Adds an option `--max-processes`/`maxProcesses` that allows for controlling how many processes should be run at once.

Closes #175
Closes #159 