### PR TITLE
Include command info and index in completion listener Promise value

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ concurrently can be used programmatically by using the API documented below:
 
 > Returns: a `Promise` that resolves if the run was successful (according to `successCondition` option),
 > or rejects, containing an array of objects with information for each command that has been run, in the order
-> that the commands terminated. The objects have the shape `{ command, name, prefixColor, env, index, exitCode }`, where
-> `index` is the index in the passed `commands` array. Default values (empty strings or objects) are returned for the
-> fields that were not specified.
+> that the commands terminated. The objects have the shape `{ command, index, exitCode }`, where `command` is the object
+> passed in the `commands` array and `index` its index there. Default values (empty strings or objects) are returned for
+> the fields that were not specified.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,10 @@ concurrently can be used programmatically by using the API documented below:
     to use when prefixing with `time`. Default: `yyyy-MM-dd HH:mm:ss.ZZZ`
 
 > Returns: a `Promise` that resolves if the run was successful (according to `successCondition` option),
-> or rejects, containing an array with the exit codes of each command that has been run.
+> or rejects, containing an array of objects with information for each command that has been run, in the order
+> that the commands terminated. The objects have the shape `{ command, name, prefixColor, env, index, exitCode }`, where
+> `index` is the index in the passed `commands` array. Default values (empty strings or objects) are returned for the
+> fields that were not specified.
 
 Example:
 

--- a/src/command.js
+++ b/src/command.js
@@ -5,11 +5,12 @@ module.exports = class Command {
         return !!this.process;
     }
 
-    constructor({ index, name, command, prefixColor, killProcess, spawn, spawnOpts }) {
+    constructor({ index, name, command, prefixColor, env, killProcess, spawn, spawnOpts }) {
         this.index = index;
         this.name = name;
         this.command = command;
         this.prefixColor = prefixColor;
+        this.env = env;
         this.killProcess = killProcess;
         this.spawn = spawn;
         this.spawnOpts = spawnOpts;
@@ -31,7 +32,14 @@ module.exports = class Command {
         });
         Rx.fromEvent(child, 'close').subscribe(([exitCode, signal]) => {
             this.process = undefined;
-            this.close.next(exitCode === null ? signal : exitCode);
+            this.close.next({
+                command: this.command,
+                name: this.name,
+                prefixColor: this.prefixColor,
+                env: this.env,
+                index: this.index,
+                exitCode: exitCode === null ? signal : exitCode,
+            });
         });
         child.stdout && pipeTo(Rx.fromEvent(child.stdout, 'data'), this.stdout);
         child.stderr && pipeTo(Rx.fromEvent(child.stderr, 'data'), this.stderr);

--- a/src/command.js
+++ b/src/command.js
@@ -33,10 +33,12 @@ module.exports = class Command {
         Rx.fromEvent(child, 'close').subscribe(([exitCode, signal]) => {
             this.process = undefined;
             this.close.next({
-                command: this.command,
-                name: this.name,
-                prefixColor: this.prefixColor,
-                env: this.env,
+                command: {
+                    command: this.command,
+                    name: this.name,
+                    prefixColor: this.prefixColor,
+                    env: this.env,
+                },
                 index: this.index,
                 exitCode: exitCode === null ? signal : exitCode,
             });

--- a/src/command.spec.js
+++ b/src/command.spec.js
@@ -83,20 +83,21 @@ describe('#start()', () => {
 
     it('shares closes to the close stream with command info and index', done => {
         const process = createProcess();
-        const command = new Command({
+        const commandInfo = {
             command: 'cmd',
             name: 'name',
             prefixColor: 'green',
             env: { VAR: 'yes' },
-            index: 1,
-            spawn: () => process,
-        });
+        };
+        const command = new Command(
+            Object.assign({
+                index: 1,
+                spawn: () => process
+            }, commandInfo)
+        );
 
         command.close.subscribe(data => {
-            expect(data.command).toBe('cmd');
-            expect(data.name).toBe('name');
-            expect(data.prefixColor).toBe('green');
-            expect(data.env).toEqual({ VAR: 'yes' });
+            expect(data.command).toEqual(commandInfo);
             expect(data.index).toBe(1);
             done();
         });

--- a/src/command.spec.js
+++ b/src/command.spec.js
@@ -59,7 +59,7 @@ describe('#start()', () => {
         const command = new Command({ spawn: () => process });
 
         command.close.subscribe(data => {
-            expect(data).toBe(0);
+            expect(data.exitCode).toBe(0);
             expect(command.process).toBeUndefined();
             done();
         });
@@ -73,12 +73,36 @@ describe('#start()', () => {
         const command = new Command({ spawn: () => process });
 
         command.close.subscribe(data => {
-            expect(data).toBe('SIGKILL');
+            expect(data.exitCode).toBe('SIGKILL');
             done();
         });
 
         command.start();
         process.emit('close', null, 'SIGKILL');
+    });
+
+    it('shares closes to the close stream with command info and index', done => {
+        const process = createProcess();
+        const command = new Command({
+            command: 'cmd',
+            name: 'name',
+            prefixColor: 'green',
+            env: { VAR: 'yes' },
+            index: 1,
+            spawn: () => process,
+        });
+
+        command.close.subscribe(data => {
+            expect(data.command).toBe('cmd');
+            expect(data.name).toBe('name');
+            expect(data.prefixColor).toBe('green');
+            expect(data.env).toEqual({ VAR: 'yes' });
+            expect(data.index).toBe(1);
+            done();
+        });
+
+        command.start();
+        process.emit('close', 0, null);
     });
 
     it('shares stdout to the stdout stream', done => {

--- a/src/completion-listener.js
+++ b/src/completion-listener.js
@@ -27,10 +27,10 @@ module.exports = class CompletionListener {
         return Rx.merge(...closeStreams)
             .pipe(
                 bufferCount(closeStreams.length),
-                switchMap(exitCodes =>
-                    this.isSuccess(exitCodes)
-                        ? Rx.of(exitCodes, this.scheduler)
-                        : Rx.throwError(exitCodes, this.scheduler)
+                switchMap(exitInfos =>
+                    this.isSuccess(exitInfos.map(({ exitCode }) => exitCode))
+                        ? Rx.of(exitInfos, this.scheduler)
+                        : Rx.throwError(exitInfos, this.scheduler)
                 ),
                 take(1)
             )

--- a/src/completion-listener.spec.js
+++ b/src/completion-listener.spec.js
@@ -19,23 +19,23 @@ describe('with default success condition set', () => {
     it('succeeds if all processes exited with code 0', () => {
         const result = createController().listen(commands);
 
-        commands[0].close.next(0);
-        commands[1].close.next(0);
+        commands[0].close.next({ exitCode: 0 });
+        commands[1].close.next({ exitCode: 0 });
 
         scheduler.flush();
 
-        return expect(result).resolves.toEqual([0, 0]);
+        return expect(result).resolves.toEqual([{ exitCode: 0 }, { exitCode: 0 }]);
     });
 
     it('fails if one of the processes exited with non-0 code', () => {
         const result = createController().listen(commands);
 
-        commands[0].close.next(0);
-        commands[1].close.next(1);
+        commands[0].close.next({ exitCode: 0 });
+        commands[1].close.next({ exitCode: 1 });
 
         scheduler.flush();
 
-        expect(result).rejects.toEqual([0, 1]);
+        expect(result).rejects.toEqual([{ exitCode: 0 }, { exitCode: 1 }]);
     });
 });
 
@@ -43,23 +43,23 @@ describe('with success condition set to first', () => {
     it('succeeds if first process to exit has code 0', () => {
         const result = createController('first').listen(commands);
 
-        commands[1].close.next(0);
-        commands[0].close.next(1);
+        commands[1].close.next({ exitCode: 0 });
+        commands[0].close.next({ exitCode: 1 });
 
         scheduler.flush();
 
-        return expect(result).resolves.toEqual([0, 1]);
+        return expect(result).resolves.toEqual([{ exitCode: 0 }, { exitCode: 1 }]);
     });
 
     it('fails if first process to exit has non-0 code', () => {
         const result = createController('first').listen(commands);
 
-        commands[1].close.next(1);
-        commands[0].close.next(0);
+        commands[1].close.next({ exitCode: 1 });
+        commands[0].close.next({ exitCode: 0 });
 
         scheduler.flush();
 
-        return expect(result).rejects.toEqual([1, 0]);
+        return expect(result).rejects.toEqual([{ exitCode: 1 }, { exitCode: 0 }]);
     });
 });
 
@@ -67,22 +67,22 @@ describe('with success condition set to last', () => {
     it('succeeds if last process to exit has code 0', () => {
         const result = createController('last').listen(commands);
 
-        commands[1].close.next(1);
-        commands[0].close.next(0);
+        commands[1].close.next({ exitCode: 1 });
+        commands[0].close.next({ exitCode: 0 });
 
         scheduler.flush();
 
-        return expect(result).resolves.toEqual([1, 0]);
+        return expect(result).resolves.toEqual([{ exitCode: 1 }, { exitCode: 0 }]);
     });
 
     it('fails if last process to exit has non-0 code', () => {
         const result = createController('last').listen(commands);
 
-        commands[1].close.next(0);
-        commands[0].close.next(1);
+        commands[1].close.next({ exitCode: 0 });
+        commands[0].close.next({ exitCode: 1 });
 
         scheduler.flush();
 
-        return expect(result).rejects.toEqual([0, 1]);
+        return expect(result).rejects.toEqual([{ exitCode: 0 }, { exitCode: 1 }]);
     });
 });

--- a/src/flow-control/kill-on-signal.js
+++ b/src/flow-control/kill-on-signal.js
@@ -16,8 +16,9 @@ module.exports = class KillOnSignal {
         });
 
         return commands.map(command => {
-            const closeStream = command.close.pipe(map(value => {
-                return caughtSignal === 'SIGINT' ? 0 : value;
+            const closeStream = command.close.pipe(map(exitInfo => {
+                const exitCode = caughtSignal === 'SIGINT' ? 0 : exitInfo.exitCode;
+                return Object.assign({}, exitInfo, { exitCode });
             }));
             return new Proxy(command, {
                 get(target, prop) {

--- a/src/flow-control/kill-on-signal.spec.js
+++ b/src/flow-control/kill-on-signal.spec.js
@@ -33,10 +33,10 @@ it('returns commands that map SIGINT to exit code 0', () => {
     process.emit('SIGINT');
 
     // A fake command's .kill() call won't trigger a close event automatically...
-    commands[0].close.next(1);
+    commands[0].close.next({ exitCode: 1 });
 
-    expect(callback).not.toHaveBeenCalledWith('SIGINT');
-    expect(callback).toHaveBeenCalledWith(0);
+    expect(callback).not.toHaveBeenCalledWith({ exitCode: 'SIGINT' });
+    expect(callback).toHaveBeenCalledWith({ exitCode: 0 });
 });
 
 it('returns commands that keep non-SIGINT exit codes', () => {
@@ -46,9 +46,9 @@ it('returns commands that keep non-SIGINT exit codes', () => {
 
     const callback = jest.fn();
     newCommands[0].close.subscribe(callback);
-    commands[0].close.next(1);
+    commands[0].close.next({ exitCode: 1 });
 
-    expect(callback).toHaveBeenCalledWith(1);
+    expect(callback).toHaveBeenCalledWith({ exitCode: 1 });
 });
 
 it('kills all commands on SIGINT', () => {

--- a/src/flow-control/kill-others.js
+++ b/src/flow-control/kill-others.js
@@ -18,7 +18,7 @@ module.exports = class KillOthers {
         }
 
         const closeStates = commands.map(command => command.close.pipe(
-            map(exitCode => exitCode === 0 ? 'success' : 'failure'),
+            map(({ exitCode }) => exitCode === 0 ? 'success' : 'failure'),
             filter(state => conditions.includes(state))
         ));
 

--- a/src/flow-control/kill-others.spec.js
+++ b/src/flow-control/kill-others.spec.js
@@ -27,7 +27,7 @@ it('returns same commands', () => {
 it('does not kill others if condition does not match', () => {
     createWithConditions(['failure']).handle(commands);
     commands[1].killable = true;
-    commands[0].close.next(0);
+    commands[0].close.next({ exitCode: 0 });
 
     expect(logger.logGlobalEvent).not.toHaveBeenCalled();
     expect(commands[0].kill).not.toHaveBeenCalled();
@@ -37,7 +37,7 @@ it('does not kill others if condition does not match', () => {
 it('kills other killable processes on success', () => {
     createWithConditions(['success']).handle(commands);
     commands[1].killable = true;
-    commands[0].close.next(0);
+    commands[0].close.next({ exitCode: 0 });
 
     expect(logger.logGlobalEvent).toHaveBeenCalledTimes(1);
     expect(logger.logGlobalEvent).toHaveBeenCalledWith('Sending SIGTERM to other processes..');
@@ -48,7 +48,7 @@ it('kills other killable processes on success', () => {
 it('kills other killable processes on failure', () => {
     createWithConditions(['failure']).handle(commands);
     commands[1].killable = true;
-    commands[0].close.next(1);
+    commands[0].close.next({ exitCode: 1 });
 
     expect(logger.logGlobalEvent).toHaveBeenCalledTimes(1);
     expect(logger.logGlobalEvent).toHaveBeenCalledWith('Sending SIGTERM to other processes..');
@@ -58,7 +58,7 @@ it('kills other killable processes on failure', () => {
 
 it('does not try to kill processes already dead', () => {
     createWithConditions(['failure']).handle(commands);
-    commands[0].close.next(1);
+    commands[0].close.next({ exitCode: 1 });
 
     expect(logger.logGlobalEvent).not.toHaveBeenCalled();
     expect(commands[0].kill).not.toHaveBeenCalled();

--- a/src/flow-control/log-exit.js
+++ b/src/flow-control/log-exit.js
@@ -4,8 +4,8 @@ module.exports = class LogExit {
     }
 
     handle(commands) {
-        commands.forEach(command => command.close.subscribe(code => {
-            this.logger.logCommandEvent(`${command.command} exited with code ${code}`, command);
+        commands.forEach(command => command.close.subscribe(({ exitCode }) => {
+            this.logger.logCommandEvent(`${command.command} exited with code ${exitCode}`, command);
         }));
 
         return commands;

--- a/src/flow-control/log-exit.spec.js
+++ b/src/flow-control/log-exit.spec.js
@@ -21,8 +21,8 @@ it('returns same commands', () => {
 it('logs the close event of each command', () => {
     controller.handle(commands);
 
-    commands[0].close.next(0);
-    commands[1].close.next('SIGTERM');
+    commands[0].close.next({ exitCode: 0 });
+    commands[1].close.next({ exitCode: 'SIGTERM' });
 
     expect(logger.logCommandEvent).toHaveBeenCalledTimes(2);
     expect(logger.logCommandEvent).toHaveBeenCalledWith(

--- a/src/flow-control/restart-process.spec.js
+++ b/src/flow-control/restart-process.spec.js
@@ -25,8 +25,8 @@ beforeEach(() => {
 it('does not restart processes that complete with success', () => {
     controller.handle(commands);
 
-    commands[0].close.next(0);
-    commands[1].close.next(0);
+    commands[0].close.next({ exitCode: 0 });
+    commands[1].close.next({ exitCode: 0 });
 
     scheduler.flush();
 
@@ -37,8 +37,8 @@ it('does not restart processes that complete with success', () => {
 it('restarts processes that fail after delay has passed', () => {
     controller.handle(commands);
 
-    commands[0].close.next(1);
-    commands[1].close.next(0);
+    commands[0].close.next({ exitCode: 1 });
+    commands[1].close.next({ exitCode: 0 });
 
     scheduler.flush();
 
@@ -54,10 +54,10 @@ it('restarts processes that fail after delay has passed', () => {
 it('restarts processes up to tries', () => {
     controller.handle(commands);
 
-    commands[0].close.next(1);
-    commands[0].close.next('SIGTERM');
-    commands[0].close.next('SIGTERM');
-    commands[1].close.next(0);
+    commands[0].close.next({ exitCode: 1 });
+    commands[0].close.next({ exitCode: 'SIGTERM' });
+    commands[0].close.next({ exitCode: 'SIGTERM' });
+    commands[1].close.next({ exitCode: 0 });
 
     scheduler.flush();
 
@@ -72,9 +72,9 @@ it('restarts processes up to tries', () => {
 it('restarts processes until they succeed', () => {
     controller.handle(commands);
 
-    commands[0].close.next(1);
-    commands[0].close.next(0);
-    commands[1].close.next(0);
+    commands[0].close.next({ exitCode: 1 });
+    commands[0].close.next({ exitCode: 0 });
+    commands[1].close.next({ exitCode: 0 });
 
     scheduler.flush();
 
@@ -105,11 +105,11 @@ describe('returned commands', () => {
         newCommands[0].close.subscribe(callback);
         newCommands[1].close.subscribe(callback);
 
-        commands[0].close.next(1);
-        commands[0].close.next(1);
-        commands[0].close.next(1);
-        commands[1].close.next(1);
-        commands[1].close.next(0);
+        commands[0].close.next({ exitCode: 1 });
+        commands[0].close.next({ exitCode: 1 });
+        commands[0].close.next({ exitCode: 1 });
+        commands[1].close.next({ exitCode: 1 });
+        commands[1].close.next({ exitCode: 0 });
 
         scheduler.flush();
 


### PR DESCRIPTION
Return command information and index in addition to the exit code in the command close stream and the completion listener Promise value. This way we can associate the exit codes with the commands when using `concurrently` programmatically.

Resolves #181.

I also tried if I could use another stream (something like `closeWithCommandInfo`) for just the additional information, so that I wouldn't need to change so many places, but I had some confusing errors in the binary unit tests, and in the end, having a single close stream seems more reasonable.