### PR TITLE
logger: do not trim prefix

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -53,7 +53,7 @@ module.exports = class Logger {
         return _.reduce(prefixes, (prev, val, key) => {
             const keyRegex = new RegExp(_.escapeRegExp(`{${key}}`), 'g');
             return prev.replace(keyRegex, val);
-        }, prefix).trim();
+        }, prefix);
     }
 
     colorText(command, text) {

--- a/src/logger.spec.js
+++ b/src/logger.spec.js
@@ -125,6 +125,13 @@ describe('#logCommandText()', () => {
         expect(logger.log).toHaveBeenCalledWith(chalk.gray.dim('0-bar') + ' ', 'foo');
     });
 
+    it('does not strip spaces from beginning or end of prefixFormat', () => {
+        const logger = createLogger({ prefixFormat: ' {index}-{name} ' });
+        logger.logCommandText('foo', { index: 0, name: 'bar' });
+
+        expect(logger.log).toHaveBeenCalledWith(chalk.gray.dim(' 0-bar ') + ' ', 'foo');
+    });
+
     it('logs with no prefix', () => {
         const logger = createLogger({ prefixFormat: 'none' });
         logger.logCommandText('foo', { command: 'echo foo' });


### PR DESCRIPTION
The logger should preserve any leading/trailing white space provided in the prefix

Closes #227

Side note: I'm keeping boilerplate code here just because I see it within the rest of the logger specification. Normally I'd DRY it up a bit with test generators or a `beforeEach`, but I'm unsure if that is a welcome change.