### PR TITLE
Test cleanup

### DIFF
--- a/src/logger.spec.js
+++ b/src/logger.spec.js
@@ -14,7 +14,7 @@ const createLogger = options => {
     return logger;
 };
 
-describe('#log()', () => {
+describe(Logger.prototype.log, () => {
     it('writes prefix + text to the output stream', () => {
         const logger = new Logger({ outputStream });
         logger.log('foo', 'bar');
@@ -52,7 +52,7 @@ describe('#log()', () => {
     });
 });
 
-describe('#logGlobalEvent()', () => {
+describe(Logger.prototype.logGlobalEvent, () => {
     it('does nothing if in raw mode', () => {
         const logger = createLogger({ raw: true });
         logger.logGlobalEvent('foo');
@@ -71,7 +71,7 @@ describe('#logGlobalEvent()', () => {
     });
 });
 
-describe('#logCommandText()', () => {
+describe(Logger.prototype.logCommandText, () => {
     it('logs with name if no prefixFormat is set', () => {
         const logger = createLogger();
         logger.logCommandText('foo', { name: 'bla' });
@@ -168,7 +168,7 @@ describe('#logCommandText()', () => {
     });
 });
 
-describe('#logCommandEvent()', () => {
+describe(Logger.prototype.logCommandEvent, () => {
     it('does nothing if in raw mode', () => {
         const logger = createLogger({ raw: true });
         logger.logCommandEvent('foo');


### PR DESCRIPTION
I had mentioned in #231 about cleanup of some tests, and this is the pull request for that cleanup.

Originally, I had intended to reduce the `logCommandText` section to use generated tests via Jest's `test.each` functionality. However, due to the way the descriptions and options are used, leaving the tests to be written as-is ends up being simpler to understand and modify.

What's left is just a cleanup of using references to the Logger prototype for descriptions instead of strings, using template literals instead of string addition, and instantiate a `Logger` instance the same way across the specification (using the `createLogger` function defined in the specification).