### PR TITLE
Include `killed` boolean in command result

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ concurrently can be used programmatically by using the API documented below:
 
 > Returns: a `Promise` that resolves if the run was successful (according to `successCondition` option),
 > or rejects, containing an array of objects with information for each command that has been run, in the order
-> that the commands terminated. The objects have the shape `{ command, index, exitCode }`, where `command` is the object
-> passed in the `commands` array and `index` its index there. Default values (empty strings or objects) are returned for
-> the fields that were not specified.
+> that the commands terminated. The objects have the shape `{ command, index, exitCode, killed }`, where `command` is the object
+> passed in the `commands` array, `index` its index there and `killed` indicates if the process was killed as a result of 
+> `killOthers`. Default values (empty strings or objects) are returned for the fields that were not specified.
 
 Example:
 

--- a/bin/concurrently.spec.js
+++ b/bin/concurrently.spec.js
@@ -1,7 +1,7 @@
 const readline = require('readline');
 const _ = require('lodash');
 const Rx = require('rxjs');
-const { buffer, map } = require('rxjs/operators');
+const { buffer, map, toArray } = require('rxjs/operators');
 const spawn = require('spawn-command');
 
 const isWindows = process.platform === 'win32';
@@ -300,7 +300,7 @@ describe('--kill-others-on-fail', () => {
 });
 
 describe('--handle-input', () => {
-    it('is alised to -i', done => {
+    it('is aliased to -i', done => {
         const child = run('-i "node fixtures/read-echo.js"');
         child.log.subscribe(line => {
             if (/READING/.test(line)) {

--- a/bin/concurrently.spec.js
+++ b/bin/concurrently.spec.js
@@ -1,7 +1,7 @@
 const readline = require('readline');
 const _ = require('lodash');
 const Rx = require('rxjs');
-const { buffer, map, toArray } = require('rxjs/operators');
+const { buffer, map } = require('rxjs/operators');
 const spawn = require('spawn-command');
 
 const isWindows = process.platform === 'win32';

--- a/src/command.js
+++ b/src/command.js
@@ -14,6 +14,7 @@ module.exports = class Command {
         this.killProcess = killProcess;
         this.spawn = spawn;
         this.spawnOpts = spawnOpts;
+        this.killed = false;
 
         this.error = new Rx.Subject();
         this.close = new Rx.Subject();
@@ -41,6 +42,7 @@ module.exports = class Command {
                 },
                 index: this.index,
                 exitCode: exitCode === null ? signal : exitCode,
+                killed: this.killed,
             });
         });
         child.stdout && pipeTo(Rx.fromEvent(child.stdout, 'data'), this.stdout);
@@ -50,6 +52,7 @@ module.exports = class Command {
 
     kill(code) {
         if (this.killable) {
+            this.killed = true;
             this.killProcess(this.pid, code);
         }
     }

--- a/src/command.spec.js
+++ b/src/command.spec.js
@@ -60,6 +60,7 @@ describe('#start()', () => {
 
         command.close.subscribe(data => {
             expect(data.exitCode).toBe(0);
+            expect(data.killed).toBe(false);
             expect(command.process).toBeUndefined();
             done();
         });
@@ -74,6 +75,7 @@ describe('#start()', () => {
 
         command.close.subscribe(data => {
             expect(data.exitCode).toBe('SIGKILL');
+            expect(data.killed).toBe(false);
             done();
         });
 
@@ -98,6 +100,7 @@ describe('#start()', () => {
 
         command.close.subscribe(data => {
             expect(data.command).toEqual(commandInfo);
+            expect(data.killed).toBe(false);
             expect(data.index).toBe(1);
             done();
         });
@@ -163,5 +166,18 @@ describe('#kill()', () => {
         command.kill();
 
         expect(killProcess).not.toHaveBeenCalled();
+    });
+
+    it('should mark the command as killed', done => {
+        command.start();
+        
+        command.close.subscribe(data => {
+            expect(data.exitCode).toBe(1);
+            expect(data.killed).toBe(true);
+            done();
+        });
+
+        command.kill();
+        process.emit('close', 1, null);
     });
 });

--- a/src/command.spec.js
+++ b/src/command.spec.js
@@ -168,7 +168,7 @@ describe('#kill()', () => {
         expect(killProcess).not.toHaveBeenCalled();
     });
 
-    it('should mark the command as killed', done => {
+    it('marks the command as killed', done => {
         command.start();
         
         command.close.subscribe(data => {

--- a/src/completion-listener.js
+++ b/src/completion-listener.js
@@ -1,5 +1,5 @@
 const Rx = require('rxjs');
-const { bufferCount, map, switchMap, take } = require('rxjs/operators');
+const { bufferCount, switchMap, take } = require('rxjs/operators');
 
 module.exports = class CompletionListener {
     constructor({ successCondition, scheduler }) {


### PR DESCRIPTION
The exit code of each command is already included in the result but the usefulness of this is limited if concurrently is run with `killOthers`. When parsing the result you do not know if a non-0 exit code is because the command failed or if it was killed by concurrently.

Adding this option allows you to print a message at the end identifying exactly which commands caused the initial failure.