### PR TITLE
fix: cwd option not overwriting per command if specified in programmatic usage

### DIFF
--- a/src/concurrently.js
+++ b/src/concurrently.js
@@ -69,6 +69,7 @@ function mapToCommandInfo(command) {
         name: command.name || '',
         prefixColor: command.prefixColor || '',
         env: command.env || {},
+        cwd: command.cwd || '',
     };
 }
 

--- a/src/concurrently.spec.js
+++ b/src/concurrently.spec.js
@@ -143,3 +143,25 @@ it('uses cwd from options for each command', () => {
         cwd: 'foobar',
     }));
 });
+
+it('uses overridden cwd option for each command if specified', () => {
+    create(
+        [
+            { command: 'echo', env: { foo: 'bar' }, cwd: 'baz' },
+            { command: 'echo', env: { foo: 'baz' } },
+        ],
+        {
+            cwd: 'foobar',
+        }
+    );
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenCalledWith('echo', expect.objectContaining({
+        env: expect.objectContaining({ foo: 'bar' }),
+        cwd: 'baz',
+    }));
+    expect(spawn).toHaveBeenCalledWith('echo', expect.objectContaining({
+        env: expect.objectContaining({ foo: 'baz' }),
+        cwd: 'foobar',
+    }));
+});


### PR DESCRIPTION
Noticed this while using this library for the first time, so sorry if I missed something. The recently added `cwd` option for the programmatic usage works but the override for each command doesn't, it was just silently dropped. This should fix that issue. I also noticed there were no tests that would pick up on it, so added one, although I'm not well versed on writing tests so it may need some modifications.