### PR TITLE
Add `cwd` to `mapToCommandInfo`

### DIFF
--- a/src/concurrently.js
+++ b/src/concurrently.js
@@ -69,6 +69,7 @@ function mapToCommandInfo(command) {
         name: command.name || '',
         prefixColor: command.prefixColor || '',
         env: command.env || {},
+        cwd: command.cwd || '',
     };
 }
 


### PR DESCRIPTION
Fix missing `cwd` property on parsed command object.