### PR TITLE
Fixed input handler when input contains a colon

### DIFF
--- a/src/flow-control/input-handler.js
+++ b/src/flow-control/input-handler.js
@@ -18,7 +18,7 @@ module.exports = class InputHandler {
         Rx.fromEvent(this.inputStream, 'data')
             .pipe(map(data => data.toString()))
             .subscribe(data => {
-                let [targetId, input] = data.split(':', 2);
+                let [targetId, input] = data.split(/:(.+)/);
                 targetId = input ? targetId : this.defaultInputTarget;
                 input = input || data;
 

--- a/src/flow-control/input-handler.spec.js
+++ b/src/flow-control/input-handler.spec.js
@@ -48,6 +48,18 @@ it('forwards input stream to target index specified in input', () => {
     expect(commands[1].stdin.write).toHaveBeenCalledWith('something');
 });
 
+it('forwards input stream to target index specified in input when input contains colon', () => {
+    controller.handle(commands);
+
+    inputStream.emit('data', Buffer.from('1::something'));
+    inputStream.emit('data', Buffer.from('1:some:thing'));
+
+    expect(commands[0].stdin.write).not.toHaveBeenCalled();
+    expect(commands[1].stdin.write).toHaveBeenCalledTimes(2);
+    expect(commands[1].stdin.write).toHaveBeenCalledWith(':something');
+    expect(commands[1].stdin.write).toHaveBeenCalledWith('some:thing');
+});
+
 it('forwards input stream to target name specified in input', () => {
     controller.handle(commands);
 


### PR DESCRIPTION
Hey there,

thanks for concurrently, we are really enjoying using it our current project! Saves everyone from having to run dozens of scrips manually when running it.

As of now --handle-input does not like `:` colons (e.g. `2:MyProject.Module.func(a: 1)`), always redirecting it to the default input target instead of the one specified.

This is due to the `limit` option on the `String.split` function simply counter intuitively omits all matches beyond the limit. (`'a:b:c'.split(':', 2) == ['a', 'b']`)

This PR fixes this behavior.